### PR TITLE
Support configuration of the default path

### DIFF
--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -12,4 +12,12 @@ defmodule Livebook.Config do
       {:longnames, _name} -> false
     end
   end
+
+  @doc """
+  Return the root path for persisting notebooks.
+  """
+  @spec root_path() :: binary()
+  def root_path() do
+    Application.get_env(:livebook, :root_path, File.cwd!())
+  end
 end

--- a/lib/livebook_web/live/home_live.ex
+++ b/lib/livebook_web/live/home_live.ex
@@ -160,7 +160,7 @@ defmodule LivebookWeb.HomeLive do
 
   def handle_info(_message, socket), do: {:noreply, socket}
 
-  defp default_path(), do: File.cwd!() <> "/"
+  defp default_path(), do: Livebook.Config.root_path() <> "/"
 
   defp sort_session_summaries(session_summaries) do
     Enum.sort_by(session_summaries, & &1.notebook_name)

--- a/lib/livebook_web/live/session_live/persistence_component.ex
+++ b/lib/livebook_web/live/session_live/persistence_component.ex
@@ -89,7 +89,7 @@ defmodule LivebookWeb.SessionLive.PersistenceComponent do
   end
 
   defp default_path() do
-    File.cwd!() |> Path.join("notebook")
+    Livebook.Config.root_path() |> Path.join("notebook")
   end
 
   defp path_savable?(nil, _running_paths), do: true


### PR DESCRIPTION
This adds a `:default_path` key to the application environment so that
file dialogs can default to known location where notebooks are stored.
