### PR TITLE
Improvements to runtime initialization

### DIFF
--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -31,7 +31,7 @@ defmodule Livebook.Runtime.ElixirStandalone do
   @spec init() :: {:ok, t()} | {:error, String.t()}
   def init() do
     parent_node = node()
-    child_node = random_node_name()
+    child_node = child_node_name(parent_node)
 
     Utils.temporarily_register(self(), child_node, fn ->
       argv = [parent_node]

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -32,12 +32,13 @@ defmodule Livebook.Runtime.ElixirStandalone do
   def init() do
     parent_node = node()
     child_node = random_node_name()
-    parent_process_name = random_process_name()
 
-    Utils.temporarily_register(self(), parent_process_name, fn ->
+    Utils.temporarily_register(self(), child_node, fn ->
+      argv = [parent_node]
+
       with {:ok, elixir_path} <- find_elixir_executable(),
-           eval <- child_node_ast(parent_node, parent_process_name) |> Macro.to_string(),
-           port <- start_elixir_node(elixir_path, child_node, eval),
+           eval = Macro.to_string(child_node_ast()),
+           port = start_elixir_node(elixir_path, child_node, eval, argv),
            {:ok, primary_pid} <- parent_init_sequence(child_node, port) do
         runtime = %__MODULE__{
           node: child_node,
@@ -52,13 +53,12 @@ defmodule Livebook.Runtime.ElixirStandalone do
     end)
   end
 
-  defp start_elixir_node(elixir_path, node_name, eval) do
+  defp start_elixir_node(elixir_path, node_name, eval, argv) do
     # Here we create a port to start the system process in a non-blocking way.
     Port.open({:spawn_executable, elixir_path}, [
       :binary,
-      :nouse_stdio,
       :hide,
-      args: elixir_flags(node_name) ++ ["--eval", eval]
+      args: elixir_flags(node_name) ++ ["--eval", eval, "--" | Enum.map(argv, &to_string/1)]
     ])
   end
 end

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -37,8 +37,7 @@ defmodule Livebook.Runtime.ElixirStandalone do
       argv = [parent_node]
 
       with {:ok, elixir_path} <- find_elixir_executable(),
-           eval = Macro.to_string(child_node_ast()),
-           port = start_elixir_node(elixir_path, child_node, eval, argv),
+           port = start_elixir_node(elixir_path, child_node, child_node_eval_string(), argv),
            {:ok, primary_pid} <- parent_init_sequence(child_node, port) do
         runtime = %__MODULE__{
           node: child_node,

--- a/lib/livebook/runtime/mix_standalone.ex
+++ b/lib/livebook/runtime/mix_standalone.ex
@@ -54,7 +54,7 @@ defmodule Livebook.Runtime.MixStandalone do
         with {:ok, elixir_path} <- find_elixir_executable(),
              :ok <- run_mix_task("deps.get", project_path, output_emitter),
              :ok <- run_mix_task("compile", project_path, output_emitter),
-             eval = Macro.to_string(child_node_ast()),
+             eval = child_node_eval_string(),
              port = start_elixir_mix_node(elixir_path, child_node, eval, argv, project_path),
              {:ok, primary_pid} <- parent_init_sequence(child_node, port, output_emitter) do
           runtime = %__MODULE__{

--- a/lib/livebook/runtime/mix_standalone.ex
+++ b/lib/livebook/runtime/mix_standalone.ex
@@ -46,7 +46,7 @@ defmodule Livebook.Runtime.MixStandalone do
 
     spawn_link(fn ->
       parent_node = node()
-      child_node = random_node_name()
+      child_node = child_node_name(parent_node)
 
       Utils.temporarily_register(self(), child_node, fn ->
         argv = [parent_node]

--- a/lib/livebook/runtime/mix_standalone.ex
+++ b/lib/livebook/runtime/mix_standalone.ex
@@ -47,14 +47,15 @@ defmodule Livebook.Runtime.MixStandalone do
     spawn_link(fn ->
       parent_node = node()
       child_node = random_node_name()
-      parent_process_name = random_process_name()
 
-      Utils.temporarily_register(self(), parent_process_name, fn ->
+      Utils.temporarily_register(self(), child_node, fn ->
+        argv = [parent_node]
+
         with {:ok, elixir_path} <- find_elixir_executable(),
              :ok <- run_mix_task("deps.get", project_path, output_emitter),
              :ok <- run_mix_task("compile", project_path, output_emitter),
-             eval <- child_node_ast(parent_node, parent_process_name) |> Macro.to_string(),
-             port <- start_elixir_mix_node(elixir_path, child_node, eval, project_path),
+             eval = Macro.to_string(child_node_ast()),
+             port = start_elixir_mix_node(elixir_path, child_node, eval, argv, project_path),
              {:ok, primary_pid} <- parent_init_sequence(child_node, port, output_emitter) do
           runtime = %__MODULE__{
             node: child_node,
@@ -86,14 +87,16 @@ defmodule Livebook.Runtime.MixStandalone do
     end
   end
 
-  defp start_elixir_mix_node(elixir_path, node_name, eval, project_path) do
+  defp start_elixir_mix_node(elixir_path, node_name, eval, argv, project_path) do
     # Here we create a port to start the system process in a non-blocking way.
     Port.open({:spawn_executable, elixir_path}, [
       :binary,
       :stderr_to_stdout,
       :hide,
-      args: elixir_flags(node_name) ++ ["-S", "mix", "run", "--eval", eval],
-      cd: project_path
+      cd: project_path,
+      args:
+        elixir_flags(node_name) ++
+          ["-S", "mix", "run", "--eval", eval, "--" | Enum.map(argv, &to_string/1)]
     ])
   end
 end

--- a/lib/livebook/runtime/standalone_init.ex
+++ b/lib/livebook/runtime/standalone_init.ex
@@ -11,22 +11,9 @@ defmodule Livebook.Runtime.StandaloneInit do
   @doc """
   Returns a random name for a dynamically spawned node.
   """
-  @spec random_node_name() :: atom()
-  def random_node_name() do
-    Utils.node_from_name("livebook_runtime_#{Utils.random_short_id()}")
-  end
-
-  @doc """
-  Returns random name to register a process under.
-
-  We have to pass parent process pid to the new Elixir node.
-  The node receives code to evaluate as string, so we cannot
-  directly embed the pid there, but we can temporarily register
-  the process under a random name and pass this name to the child node.
-  """
-  @spec random_process_name() :: atom()
-  def random_process_name() do
-    :"livebook_parent_process_name_#{Utils.random_short_id()}"
+  @spec child_node_name(atom()) :: atom()
+  def child_node_name(parent) do
+    :"#{Utils.random_short_id()}-#{parent}"
   end
 
   @doc """

--- a/lib/livebook/runtime/standalone_init.ex
+++ b/lib/livebook/runtime/standalone_init.ex
@@ -111,12 +111,9 @@ defmodule Livebook.Runtime.StandaloneInit do
     loop.(loop)
   end
 
-  # This is the primary process, so as soon as it finishes, the runtime terminates.
-  #
-  # Note Windows does not handle escaped quotes the same way as Unix, so this AST
-  # cannot have constructs that are strings. That's why we pass the parent node name
-  # as ARGV. The parent process name is assumed to be the same as the child node name.
-  # We also can't have new lines.
+  # Note Windows does not handle escaped quotes and newlines the same way as Unix,
+  # so the string cannot have constructs newlines nor strings. That's why we pass
+  # the parent node name as ARGV and write the code avoiding newlines.
   @child_node_eval_string """
   [parent_node] = System.argv();\
   init_ref = make_ref();\
@@ -139,7 +136,8 @@ defmodule Livebook.Runtime.StandaloneInit do
 
   This function returns AST that should be evaluated in primary
   process on the newly spawned child node. The executed code expects
-  the parent_node and parent_process_name on ARGV.
+  the parent_node on ARGV. The process on the parent node is assumed
+  to have the same name as the child node.
   """
   def child_node_eval_string(), do: @child_node_eval_string
 end


### PR DESCRIPTION
1. Do not use nouse_stdio as it causes slowdowns when IEx
   is also running

2. Reduce the amount of generated random atoms by using the
   child_node as the name of the parent process

3. Do not pass quoted strings to Windows to eval, use argv
   instead

Closes #194.