### PR TITLE
Fix typos in comments

### DIFF
--- a/lib/livebook/evaluator.ex
+++ b/lib/livebook/evaluator.ex
@@ -33,7 +33,7 @@ defmodule Livebook.Evaluator do
   @type ref :: term()
 
   @typedoc """
-  Either {:ok, result} for successfull evaluation
+  Either {:ok, result} for successful evaluation
   or {:error, kind, error, stacktrace} for a failed one.
   """
   @type evaluation_response ::

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -6,7 +6,7 @@ defmodule Livebook.Runtime.Attached do
   # Such node must be already started and available,
   # Livebook doesn't manage its lifetime in any way
   # and only loads/unloads the necessary elements.
-  # The node can be an oridinary Elixir runtime,
+  # The node can be an ordinary Elixir runtime,
   # a Mix project shell, a running release or anything else.
 
   defstruct [:node]

--- a/lib/livebook/runtime/standalone_init.ex
+++ b/lib/livebook/runtime/standalone_init.ex
@@ -36,7 +36,7 @@ defmodule Livebook.Runtime.StandaloneInit do
       if(Livebook.Config.shortnames?(), do: "--sname", else: "--name"),
       to_string(node_name),
       "--erl",
-      # Minimize shedulers busy wait threshold,
+      # Minimize schedulers busy wait threshold,
       # so that they go to sleep immediately after evaluation.
       # Enable ANSI escape codes as we handle them with HTML.
       "+sbwt none +sbwtdcpu none +sbwtdio none -elixir ansi_enabled true",

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -9,7 +9,7 @@ defmodule Livebook.Session do
   # them of any changes applied to the notebook.
   #
   # The core concept is the `Data` structure
-  # to which we can apply reproducible opreations.
+  # to which we can apply reproducible operations.
   # See `Data` for more information.
 
   use GenServer, restart: :temporary
@@ -49,7 +49,7 @@ defmodule Livebook.Session do
 
   * `:id` (**required**) - a unique identifier to register the session under
 
-  * `:notebook` - the inital `Notebook` structure (e.g. imported from a file)
+  * `:notebook` - the initial `Notebook` structure (e.g. imported from a file)
 
   * `:path` - the file to which the notebook should be saved
 
@@ -80,7 +80,7 @@ defmodule Livebook.Session do
 
   Returns the current session data, which the client can than
   keep in sync with the server by subscribing to the `sessions:id` topic
-  and reciving operations to apply.
+  and receiving operations to apply.
   """
   @spec register_client(id(), pid()) :: Data.t()
   def register_client(session_id, pid) do
@@ -559,7 +559,7 @@ defmodule Livebook.Session do
     end
   end
 
-  # Given any opeation on `Data`, the process does the following:
+  # Given any operation on `Data`, the process does the following:
   #
   #   * broadcasts the operation to all clients immediately,
   #     so that they can update their local `Data`
@@ -653,7 +653,7 @@ defmodule Livebook.Session do
   end
 
   # Checks if a runtime already set, and if that's not the case
-  # starts a new standlone one.
+  # starts a new standalone one.
   defp ensure_runtime(%{data: %{runtime: nil}} = state) do
     with {:ok, runtime} <- Runtime.ElixirStandalone.init() do
       runtime_monitor_ref = Runtime.connect(runtime)


### PR DESCRIPTION
While looking through the code for a couple things, I saw a few typos. This
fixes them.
