### PR TITLE
Add editor completion to Elixir cells

### DIFF
--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -23,3 +23,11 @@ body {
   border-top-color: #3e64ff;
   border-left-color: #3e64ff;
 }
+
+/* Monaco overrides */
+
+/* Add some spacing to code snippets in completion suggestions */
+div.suggest-details-container div.monaco-tokenized-source {
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+}

--- a/assets/js/cell/live_editor.js
+++ b/assets/js/cell/live_editor.js
@@ -8,6 +8,7 @@ import HookServerAdapter from "./live_editor/hook_server_adapter";
  */
 class LiveEditor {
   constructor(hook, container, cellId, type, source, revision) {
+    this.hook = hook;
     this.container = container;
     this.cellId = cellId;
     this.type = type;
@@ -16,6 +17,10 @@ class LiveEditor {
     this._onBlur = null;
 
     this.__mountEditor();
+
+    if (type === "elixir") {
+      this.__setupCompletion();
+    }
 
     const serverAdapter = new HookServerAdapter(hook, cellId);
     const editorAdapter = new MonacoEditorAdapter(this.editor);
@@ -119,6 +124,105 @@ class LiveEditor {
       this.container.style.height = `${contentHeight}px`;
     });
   }
+
+  __setupCompletion() {
+    /**
+     * Completion happens asynchronously, the flow goes as follows:
+     *
+     *   * the user opens the completion list, which triggers the global
+     *     completion provider registered in `live_editor/monaco.js`
+     *
+     *   * the global provider delegates to the cell-specific `__getCompletionItems`
+     *     defined below. That's a little bit hacky, but this way we make
+     *     completion cell-specific
+     *
+     *   * then `__getCompletionItems` sends a completion request to the LV process
+     *     and gets a unique reference, under which it keeps completion callback
+     *
+     *   * finally the hook receives the "completion_response" event with completion items,
+     *     it looks up completion callback for the received reference and calls it
+     *     with the received items list
+     */
+
+    const completionHandlerByRef = {};
+
+    this.editor.getModel().__getCompletionItems = (model, position) => {
+      const line = model.getLineContent(position.lineNumber);
+      const lineUntilCursor = line.slice(0, position.column - 1);
+
+      return new Promise((resolve, reject) => {
+        this.hook.pushEvent(
+          "completion_request",
+          {
+            hint: lineUntilCursor,
+            cell_id: this.cellId,
+          },
+          ({ completion_ref: completionRef }) => {
+            if (completionRef) {
+              completionHandlerByRef[completionRef] = (items) => {
+                const suggestions = completionItemsToSuggestions(items);
+                resolve({ suggestions });
+              };
+            } else {
+              resolve({ suggestions: [] });
+            }
+          }
+        );
+      });
+    };
+
+    this.hook.handleEvent(
+      "completion_response",
+      ({ completion_ref: completionRef, items }) => {
+        const handler = completionHandlerByRef[completionRef];
+
+        if (handler) {
+          handler(items);
+          delete completionHandlerByRef[completionRef];
+        }
+      }
+    );
+  }
+}
+
+function completionItemsToSuggestions(items) {
+  return items.map(parseItem).map((suggestion, index) => ({
+    ...suggestion,
+    sortText: numberToSortableString(index, items.length),
+  }));
+}
+
+// See `Livebook.Runtime` for completion item definition
+function parseItem(item) {
+  return {
+    label: item.label,
+    kind: parseItemKind(item.kind),
+    detail: item.detail,
+    documentation: {
+      value: item.documentation,
+      isTrusted: true,
+    },
+    insertText: item.insert_text,
+  };
+}
+
+function parseItemKind(kind) {
+  switch (kind) {
+    case "function":
+      return monaco.languages.CompletionItemKind.Function;
+    case "module":
+      return monaco.languages.CompletionItemKind.Module;
+    case "variable":
+      return monaco.languages.CompletionItemKind.Variable;
+    case "type":
+      return monaco.languages.CompletionItemKind.Class;
+    default:
+      return null;
+  }
+}
+
+function numberToSortableString(number, maxNumber) {
+  return String(number).padStart(maxNumber, "0");
 }
 
 export default LiveEditor;

--- a/assets/js/cell/live_editor.js
+++ b/assets/js/cell/live_editor.js
@@ -84,13 +84,15 @@ class LiveEditor {
       },
       overviewRulerLanes: 0,
       scrollBeyondLastLine: false,
-      quickSuggestions: false,
       renderIndentGuides: false,
       occurrencesHighlight: false,
       renderLineHighlight: "none",
       theme: "custom",
       fontFamily: "JetBrains Mono",
       tabIndex: -1,
+      quickSuggestions: false,
+      tabCompletion: "on",
+      suggestSelection: "first",
     });
 
     this.editor.getModel().updateOptions({
@@ -198,7 +200,7 @@ function parseItem(item) {
     label: item.label,
     kind: parseItemKind(item.kind),
     detail: item.detail,
-    documentation: {
+    documentation: item.documentation && {
       value: item.documentation,
       isTrusted: true,
     },

--- a/assets/js/cell/live_editor.js
+++ b/assets/js/cell/live_editor.js
@@ -214,10 +214,12 @@ function parseItemKind(kind) {
       return monaco.languages.CompletionItemKind.Function;
     case "module":
       return monaco.languages.CompletionItemKind.Module;
-    case "variable":
-      return monaco.languages.CompletionItemKind.Variable;
     case "type":
       return monaco.languages.CompletionItemKind.Class;
+    case "variable":
+      return monaco.languages.CompletionItemKind.Variable;
+    case "field":
+      return monaco.languages.CompletionItemKind.Field;
     default:
       return null;
   }

--- a/assets/js/cell/live_editor/monaco.js
+++ b/assets/js/cell/live_editor/monaco.js
@@ -2,6 +2,7 @@ import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
 import ElixirLanguageConfiguration from "./elixir/language_configuration";
 import ElixirMonarchLanguage from "./elixir/monarch_language";
 import ElixirOnTypeFormattingEditProvider from "./elixir/on_type_formatting_edit_provider";
+import theme from "./theme";
 
 // Register the Elixir language and add relevant configuration
 monaco.languages.register({ id: "elixir" });
@@ -19,50 +20,7 @@ monaco.languages.registerOnTypeFormattingEditProvider(
 monaco.languages.setMonarchTokensProvider("elixir", ElixirMonarchLanguage);
 
 // Define custom theme
-
-monaco.editor.defineTheme("custom", {
-  base: "vs-dark",
-  inherit: false,
-  rules: [
-    { token: "", foreground: "#abb2bf" },
-    { token: "variable", foreground: "#e06c75" },
-    { token: "constant", foreground: "#61afef" },
-    { token: "constant.character.escape", foreground: "#61afef" },
-    { token: "comment", foreground: "#5c6370" },
-    { token: "number", foreground: "#61afef" },
-    { token: "regexp", foreground: "#e06c75" },
-    { token: "type", foreground: "#e06c75" },
-    { token: "string", foreground: "#98c379" },
-    { token: "keyword", foreground: "#c678dd" },
-    { token: "operator", foreground: "#d19a66" },
-    { token: "delimiter.bracket.embed", foreground: "#be5046" },
-    { token: "sigil", foreground: "#56b6c2" },
-    { token: "function", foreground: "#61afef" },
-    { token: "function.call", foreground: "#abb2bf" },
-
-    // Markdown specific
-    { token: "emphasis", fontStyle: "italic" },
-    { token: "strong", fontStyle: "bold" },
-    { token: "keyword.md", foreground: "#e06c75" },
-    { token: "keyword.table", foreground: "#e06c75" },
-    { token: "string.link.md", foreground: "#61afef" },
-    { token: "variable.md", foreground: "#56b6c2" },
-  ],
-
-  colors: {
-    "editor.background": "#282c34",
-    "editor.foreground": "#abb2bf",
-    "editorLineNumber.foreground": "#636d83",
-    "editorCursor.foreground": "#636d83",
-    "editor.selectionBackground": "#3e4451",
-    "editor.findMatchHighlightBackground": "#528bff3D",
-    "editorSuggestWidget.background": "#21252b",
-    "editorSuggestWidget.border": "#181a1f",
-    "editorSuggestWidget.selectedBackground": "#2c313a",
-    "input.background": "#1b1d23",
-    "input.border": "#181a1f",
-  },
-});
+monaco.editor.defineTheme("custom", theme);
 
 // See https://github.com/microsoft/monaco-editor/issues/648#issuecomment-564978560
 // Without this selecting text with whitespace shrinks the whitespace.
@@ -78,6 +36,20 @@ document.fonts.addEventListener("loadingdone", (event) => {
     // fonts and updates its cache.
     monaco.editor.remeasureFonts();
   }
+});
+
+// Define custom completion provider.
+// In our case the completion behaviour is cell-dependent,
+// so we delegate the implementation to the appropriate cell.
+// See cell/live_editor.js for more details.
+monaco.languages.registerCompletionItemProvider("elixir", {
+  provideCompletionItems: (model, position) => {
+    if (model.__getCompletionItems) {
+      return model.__getCompletionItems(model, position);
+    } else {
+      return [];
+    }
+  },
 });
 
 export default monaco;

--- a/assets/js/cell/live_editor/theme.js
+++ b/assets/js/cell/live_editor/theme.js
@@ -1,0 +1,47 @@
+// This is a port of the One Dark theme to the Monaco editor.
+
+const theme = {
+  base: "vs-dark",
+  inherit: false,
+  rules: [
+    { token: "", foreground: "#abb2bf" },
+    { token: "variable", foreground: "#e06c75" },
+    { token: "constant", foreground: "#61afef" },
+    { token: "constant.character.escape", foreground: "#61afef" },
+    { token: "comment", foreground: "#5c6370" },
+    { token: "number", foreground: "#61afef" },
+    { token: "regexp", foreground: "#e06c75" },
+    { token: "type", foreground: "#e06c75" },
+    { token: "string", foreground: "#98c379" },
+    { token: "keyword", foreground: "#c678dd" },
+    { token: "operator", foreground: "#d19a66" },
+    { token: "delimiter.bracket.embed", foreground: "#be5046" },
+    { token: "sigil", foreground: "#56b6c2" },
+    { token: "function", foreground: "#61afef" },
+    { token: "function.call", foreground: "#abb2bf" },
+
+    // Markdown specific
+    { token: "emphasis", fontStyle: "italic" },
+    { token: "strong", fontStyle: "bold" },
+    { token: "keyword.md", foreground: "#e06c75" },
+    { token: "keyword.table", foreground: "#e06c75" },
+    { token: "string.link.md", foreground: "#61afef" },
+    { token: "variable.md", foreground: "#56b6c2" },
+  ],
+
+  colors: {
+    "editor.background": "#282c34",
+    "editor.foreground": "#abb2bf",
+    "editorLineNumber.foreground": "#636d83",
+    "editorCursor.foreground": "#636d83",
+    "editor.selectionBackground": "#3e4451",
+    "editor.findMatchHighlightBackground": "#528bff3D",
+    "editorSuggestWidget.background": "#21252b",
+    "editorSuggestWidget.border": "#181a1f",
+    "editorSuggestWidget.selectedBackground": "#2c313a",
+    "input.background": "#1b1d23",
+    "input.border": "#181a1f",
+  },
+};
+
+export default theme;

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -119,8 +119,17 @@ function handleDocumentKeyDown(hook, event) {
     keyBuffer.reset();
 
     if (key === "Escape") {
-      // Ignore Escape if it's supposed to close some Monaco input (like the find/replace box)
-      if (!event.target.closest(".monaco-inputbox")) {
+      const monacoInputOpen = !!event.target.closest(".monaco-inputbox");
+
+      const activeDescendant = event.target.getAttribute(
+        "aria-activedescendant"
+      );
+      const completionBoxOpen =
+        activeDescendant && activeDescendant.includes("suggest");
+
+      // Ignore Escape if it's supposed to close some Monaco input
+      // (like the find/replace box), or the completion box.
+      if (!monacoInputOpen && !completionBoxOpen) {
         escapeInsertMode(hook);
       }
     } else if (cmd && key === "Enter") {

--- a/lib/livebook/completion.ex
+++ b/lib/livebook/completion.ex
@@ -32,7 +32,7 @@ defmodule Livebook.Completion do
     {completion_item_kind_priority(completion_item.kind), completion_item.label}
   end
 
-  @ordered_kinds [:variable, :module, :function, :type]
+  @ordered_kinds [:field, :variable, :module, :function, :type]
 
   defp completion_item_kind_priority(kind) when kind in @ordered_kinds do
     Enum.find_index(@ordered_kinds, &(&1 == kind))
@@ -148,23 +148,28 @@ defmodule Livebook.Completion do
   end
 
   defp complete_variable(hint, ctx) do
-    complete_key_value(ctx.binding, hint)
-  end
-
-  defp complete_map_field(map, hint) do
-    # Note: we need Map.to_list/1 in case this is a struct
-    complete_key_value(Map.to_list(map), hint)
-  end
-
-  defp complete_key_value(list, hint) do
-    for {key, value} <- list,
-        is_atom(key),
+    for {key, value} <- ctx.binding,
         name = Atom.to_string(key),
         String.starts_with?(name, hint),
         do: %{
           label: name,
           kind: :variable,
           detail: "variable",
+          documentation: value_docstr(value),
+          insert_text: name
+        }
+  end
+
+  defp complete_map_field(map, hint) do
+    # Note: we need Map.to_list/1 in case this is a struct
+    for {key, value} <- Map.to_list(map),
+        is_atom(key),
+        name = Atom.to_string(key),
+        String.starts_with?(name, hint),
+        do: %{
+          label: name,
+          kind: :field,
+          detail: "field",
           documentation: value_docstr(value),
           insert_text: name
         }

--- a/lib/livebook/completion.ex
+++ b/lib/livebook/completion.ex
@@ -1,0 +1,580 @@
+defmodule Livebook.Completion do
+  @moduledoc false
+
+  # This module provides basic intellisense completion
+  # suitable for text editors.
+  #
+  # The implementation is based primarly on `IEx.Autocomplete`.
+  # It also takes insights from `ElixirSense.Providers.Suggestion.Complete`,
+  # which is a very extensive implementation used in the Elixir Language Server.
+
+  @type completion_item :: Livebook.Runtime.completion_item()
+
+  @line_length 30
+
+  @doc """
+  Returns a list of completion suggestions for the given `hint`.
+
+  Uses evaluation binding and environment to expand aliases, imports,
+  complete nested maps, etc.
+
+  `hint` may be a single token or longer line fragment like `if Enum.m`.
+  """
+  @spec get_completion_items(String.t(), Code.binding(), Macro.Env.t()) :: list(completion_item())
+  def get_completion_items(hint, binding, env) do
+    expr = hint |> String.to_charlist() |> Enum.reverse()
+
+    expr
+    |> expand(%{binding: binding, env: env})
+    |> Enum.sort_by(&completion_item_priority/1)
+  end
+
+  defp completion_item_priority(completion_item) do
+    {completion_item_kind_priority(completion_item.kind), completion_item.label}
+  end
+
+  defp completion_item_kind_priority(kind) do
+    Enum.find_index([:variable, :module, :function, :type], &(&1 == kind))
+  end
+
+  defp expand([], ctx) do
+    expand_variable_or_import("", ctx)
+  end
+
+  defp expand([h | t] = expr, ctx) do
+    cond do
+      h == ?. and t != [] ->
+        expand_dot(reduce(t), ctx)
+
+      h == ?: and t == [] ->
+        expand_erlang_modules("")
+
+      identifier?(h) ->
+        expand_expr(reduce(expr), ctx)
+
+      h == ?/ and t != [] and identifier?(hd(t)) ->
+        expand_expr(reduce(t), ctx)
+
+      h in ' ([{,' ->
+        expand('', ctx)
+
+      true ->
+        no()
+    end
+  end
+
+  defp identifier?(h) do
+    h in ?a..?z or h in ?A..?Z or h in ?0..?9 or h in [?_, ??, ?!]
+  end
+
+  defp expand_dot(expr, ctx) do
+    case Code.string_to_quoted(expr) do
+      {:ok, atom} when is_atom(atom) ->
+        expand_call(atom, "", ctx)
+
+      {:ok, {:__aliases__, _, list}} ->
+        expand_elixir_modules(list, "", ctx)
+
+      {:ok, {_, _, _} = ast_node} ->
+        expand_call(ast_node, "", ctx)
+
+      _ ->
+        no()
+    end
+  end
+
+  defp expand_expr(expr, ctx) do
+    case Code.string_to_quoted(expr) do
+      {:ok, atom} when is_atom(atom) ->
+        expand_erlang_modules(Atom.to_string(atom))
+
+      {:ok, {atom, _, nil}} when is_atom(atom) ->
+        expand_variable_or_import(Atom.to_string(atom), ctx)
+
+      {:ok, {:__aliases__, _, [root]}} ->
+        expand_elixir_modules([], Atom.to_string(root), ctx)
+
+      {:ok, {:__aliases__, _, [h | _] = list}} when is_atom(h) ->
+        hint = Atom.to_string(List.last(list))
+        list = Enum.take(list, length(list) - 1)
+        expand_elixir_modules(list, hint, ctx)
+
+      {:ok, {{:., _, [ast_node, fun]}, _, []}} when is_atom(fun) ->
+        expand_call(ast_node, Atom.to_string(fun), ctx)
+
+      _ ->
+        no()
+    end
+  end
+
+  defp reduce(expr) do
+    [token | _] = :string.lexemes(expr, ' ([{,')
+
+    token
+    |> Enum.reverse()
+    |> trim_leading(?&)
+    |> trim_leading(?%)
+    |> trim_leading(?!)
+    |> trim_leading(?^)
+  end
+
+  defp trim_leading([char | rest], char), do: rest
+  defp trim_leading(expr, _char), do: expr
+
+  defp no do
+    []
+  end
+
+  ## Expand calls
+
+  # :atom.fun
+  defp expand_call(mod, hint, _ctx) when is_atom(mod) do
+    expand_require(mod, hint)
+  end
+
+  # Elixir.fun
+  defp expand_call({:__aliases__, _, list}, hint, ctx) do
+    case expand_alias(list, ctx) do
+      {:ok, alias} -> expand_require(alias, hint)
+      :error -> no()
+    end
+  end
+
+  # # variable.fun_or_key
+  defp expand_call({_, _, _} = ast_node, hint, ctx) do
+    case value_from_binding(ast_node, ctx) do
+      {:ok, mod} when is_atom(mod) -> expand_call(mod, hint, ctx)
+      {:ok, map} when is_map(map) -> match_map_fields(map, hint)
+      _otherwise -> no()
+    end
+  end
+
+  defp expand_call(_, _, _) do
+    no()
+  end
+
+  defp match_map_fields(map, hint) do
+    for {key, value} when is_atom(key) <- Map.to_list(map),
+        key = Atom.to_string(key),
+        String.starts_with?(key, hint),
+        do: %{
+          label: key,
+          kind: :variable,
+          detail: "variable",
+          documentation: """
+          ```
+          #{inspect(value, pretty: true, width: @line_length)}
+          ```
+          """,
+          insert_text: key
+        }
+  end
+
+  defp expand_require(mod, hint) do
+    expand_module_funs(mod, hint) ++ expand_module_types(mod, hint)
+  end
+
+  defp expand_variable_or_import(hint, ctx) do
+    variables = expand_variable(hint, ctx)
+
+    imports =
+      imports_from_env(ctx)
+      |> Enum.flat_map(fn {mod, funs} ->
+        expand_module_funs(mod, hint, funs)
+      end)
+
+    module_funs = expand_module_funs(Kernel.SpecialForms, hint)
+
+    variables ++ imports ++ module_funs
+  end
+
+  defp expand_variable(hint, ctx) do
+    variables_from_binding(hint, ctx)
+    |> Enum.map(fn {name, value} ->
+      %{
+        label: name,
+        kind: :variable,
+        detail: "variable",
+        documentation: """
+        ```
+        #{inspect(value, pretty: true, width: @line_length)}
+        ```
+        """,
+        insert_text: name
+      }
+    end)
+  end
+
+  ## Erlang modules
+
+  defp expand_erlang_modules(hint) do
+    for mod <- match_modules(hint, true), usable_as_unquoted_module?(mod) do
+      %{
+        label: mod,
+        kind: :module,
+        detail: "module",
+        # TODO: support Erlang docs
+        documentation: nil,
+        insert_text: mod
+      }
+    end
+  end
+
+  ## Elixir modules
+
+  defp expand_elixir_modules([], hint, ctx) do
+    aliases = match_aliases(hint, ctx)
+    expand_elixir_modules_from_aliases(Elixir, hint, aliases)
+  end
+
+  defp expand_elixir_modules(list, hint, ctx) do
+    case expand_alias(list, ctx) do
+      {:ok, alias} -> expand_elixir_modules_from_aliases(alias, hint, [])
+      :error -> no()
+    end
+  end
+
+  defp expand_elixir_modules_from_aliases(mod, hint, aliases) do
+    aliases
+    |> Kernel.++(match_elixir_modules(mod, hint))
+    |> Kernel.++(expand_module_funs(mod, hint))
+    |> Kernel.++(expand_module_types(mod, hint))
+  end
+
+  defp expand_alias([name | rest], ctx) when is_atom(name) do
+    case Keyword.fetch(aliases_from_env(ctx), Module.concat(Elixir, name)) do
+      {:ok, name} when rest == [] -> {:ok, name}
+      {:ok, name} -> {:ok, Module.concat([name | rest])}
+      :error -> {:ok, Module.concat([name | rest])}
+    end
+  end
+
+  defp expand_alias([_ | _], _) do
+    :error
+  end
+
+  defp match_aliases(hint, ctx) do
+    for {alias, mod} <- aliases_from_env(ctx),
+        [name] = Module.split(alias),
+        String.starts_with?(name, hint) do
+      %{
+        label: name,
+        kind: :module,
+        detail: "module",
+        documentation: mod |> get_module_doc_content() |> format_doc_content(),
+        insert_text: name
+      }
+    end
+  end
+
+  defp match_elixir_modules(module, hint) do
+    name = Atom.to_string(module)
+    depth = length(String.split(name, ".")) + 1
+    base = name <> "." <> hint
+
+    for mod <- match_modules(base, module == Elixir),
+        parts = String.split(mod, "."),
+        depth <= length(parts),
+        name = Enum.at(parts, depth - 1),
+        valid_alias_piece?("." <> name),
+        concatted = parts |> Enum.take(depth) |> Module.concat(),
+        uniq: true,
+        do: %{
+          label: name,
+          kind: :module,
+          detail: "module",
+          documentation: concatted |> get_module_doc_content() |> format_doc_content(),
+          insert_text: name
+        }
+  end
+
+  defp valid_alias_piece?(<<?., char, rest::binary>>) when char in ?A..?Z,
+    do: valid_alias_rest?(rest)
+
+  defp valid_alias_piece?(_), do: false
+
+  defp valid_alias_rest?(<<char, rest::binary>>)
+       when char in ?A..?Z
+       when char in ?a..?z
+       when char in ?0..?9
+       when char == ?_,
+       do: valid_alias_rest?(rest)
+
+  defp valid_alias_rest?(<<>>), do: true
+  defp valid_alias_rest?(rest), do: valid_alias_piece?(rest)
+
+  ## Helpers
+
+  defp usable_as_unquoted_module?(name) do
+    # Conversion to atom is not a problem because
+    # it is only called with existing modules names.
+    Code.Identifier.classify(String.to_atom(name)) != :other
+  end
+
+  defp match_modules(hint, root) do
+    get_modules(root)
+    |> Enum.sort()
+    |> Enum.dedup()
+    |> Enum.drop_while(&(not String.starts_with?(&1, hint)))
+    |> Enum.take_while(&String.starts_with?(&1, hint))
+  end
+
+  defp get_modules(true) do
+    ["Elixir.Elixir"] ++ get_modules(false)
+  end
+
+  defp get_modules(false) do
+    modules = Enum.map(:code.all_loaded(), &Atom.to_string(elem(&1, 0)))
+
+    case :code.get_mode() do
+      :interactive -> modules ++ get_modules_from_applications()
+      _otherwise -> modules
+    end
+  end
+
+  defp get_modules_from_applications do
+    for [app] <- loaded_applications(),
+        {:ok, modules} = :application.get_key(app, :modules),
+        module <- modules do
+      Atom.to_string(module)
+    end
+  end
+
+  defp loaded_applications do
+    # If we invoke :application.loaded_applications/0,
+    # it can error if we don't call safe_fixtable before.
+    # Since in both cases we are reaching over the
+    # application controller internals, we choose to match
+    # for performance.
+    :ets.match(:ac_tab, {{:loaded, :"$1"}, :_})
+  end
+
+  defp expand_module_funs(mod, hint, funs \\ nil) do
+    if ensure_loaded?(mod) do
+      docs = get_docs(mod, [:function, :macro]) || []
+      specs = get_specs(mod) || []
+      funs = funs || exports(mod)
+      funs_with_base_arity = funs_with_base_arity(docs)
+
+      funs
+      |> Enum.filter(fn {name, _arity} ->
+        name = Atom.to_string(name)
+        String.starts_with?(name, hint)
+      end)
+      |> Enum.map(fn {name, arity} ->
+        base_arity = Map.get(funs_with_base_arity, {name, arity}, arity)
+        doc = find_doc(docs, {name, base_arity})
+        spec = find_spec(specs, {name, base_arity})
+
+        docstr = doc |> doc_content() |> format_doc_content()
+        signatures = doc |> doc_signatures() |> format_signatures(mod)
+        spec = format_spec(spec)
+
+        %{
+          label: "#{name}/#{arity}",
+          kind: :function,
+          detail: signatures,
+          documentation: docstr <> "\n\n" <> spec,
+          insert_text: name
+        }
+      end)
+    else
+      []
+    end
+  end
+
+  defp funs_with_base_arity(docs) do
+    for {{_, fun_name, arity}, _, _, _, metadata} <- docs,
+        count = Map.get(metadata, :defaults, 0),
+        count > 0,
+        new_arity <- (arity - count)..(arity - 1),
+        into: %{},
+        do: {{fun_name, new_arity}, arity}
+  end
+
+  defp get_docs(mod, kinds) do
+    case Code.fetch_docs(mod) do
+      {:docs_v1, _, _, _, _, _, docs} ->
+        for {{kind, _, _}, _, _, _, _} = doc <- docs, kind in kinds, do: doc
+
+      {:error, _} ->
+        nil
+    end
+  end
+
+  defp find_doc(docs, {name, arity}) do
+    Enum.find(docs, &match?({{_, ^name, ^arity}, _, _, _, _}, &1))
+  end
+
+  defp get_specs(mod) do
+    case Code.Typespec.fetch_specs(mod) do
+      {:ok, specs} -> specs
+      :error -> nil
+    end
+  end
+
+  defp find_spec(specs, {name, arity}) do
+    Enum.find(specs, &match?({{^name, ^arity}, _}, &1))
+  end
+
+  defp doc_signatures({_, _, signatures, _, _}), do: signatures
+  defp doc_signatures(_), do: []
+
+  defp doc_content({_, _, _, %{"en" => docstr}, _}), do: docstr
+  defp doc_content(_), do: nil
+
+  defp format_signatures([], _mod), do: ""
+
+  defp format_signatures(signatures, mod) do
+    prefix = mod_to_prefix(mod)
+    Enum.map_join(signatures, "\n", &(prefix <> &1))
+  end
+
+  defp mod_to_prefix(mod) do
+    case Atom.to_string(mod) do
+      "Elixir." <> name -> name <> "."
+      name -> name <> "."
+    end
+  end
+
+  defp format_doc_content(nil), do: ""
+
+  defp format_doc_content(docstr) do
+    [leading | _] = String.split(docstr, "\n\n")
+    leading
+  end
+
+  defp format_spec(nil), do: ""
+
+  defp format_spec({{name, _arity}, spec_ast_list}) do
+    spec_lines =
+      Enum.map(spec_ast_list, fn spec_ast ->
+        spec =
+          Code.Typespec.spec_to_quoted(name, spec_ast)
+          |> Macro.to_string()
+          |> Code.format_string!(line_length: @line_length)
+
+        ["@spec ", spec]
+      end)
+
+    ["```", spec_lines, "```"]
+    |> Enum.intersperse("\n")
+    |> IO.iodata_to_binary()
+  end
+
+  defp exports(mod) do
+    if Code.ensure_loaded?(mod) and function_exported?(mod, :__info__, 1) do
+      mod.__info__(:macros) ++ (mod.__info__(:functions) -- [__info__: 1])
+    else
+      mod.module_info(:exports) -- [module_info: 0, module_info: 1]
+    end
+  end
+
+  defp expand_module_types(mod, hint) do
+    docs = get_docs(mod, [:type]) || []
+    types = get_module_types(mod)
+
+    types
+    |> Enum.filter(fn {name, _arity} ->
+      name = Atom.to_string(name)
+      String.starts_with?(name, hint)
+    end)
+    |> Enum.map(fn {name, arity} ->
+      doc = find_doc(docs, {name, arity})
+      docstr = doc |> doc_content() |> format_doc_content()
+
+      %{
+        label: "#{name}/#{arity}",
+        kind: :type,
+        detail: "typespec",
+        documentation: docstr,
+        insert_text: name
+      }
+    end)
+  end
+
+  defp get_module_types(mod) do
+    if ensure_loaded?(mod) do
+      case Code.Typespec.fetch_types(mod) do
+        {:ok, types} ->
+          for {kind, {name, _, args}} <- types,
+              kind in [:type, :opaque] do
+            {name, length(args)}
+          end
+
+        :error ->
+          []
+      end
+    else
+      []
+    end
+  end
+
+  defp get_module_doc_content(mod) do
+    case Code.fetch_docs(mod) do
+      {:docs_v1, _, _, _, %{"en" => docstring}, _, _} ->
+        docstring
+
+      _ ->
+        nil
+    end
+  end
+
+  defp ensure_loaded?(Elixir), do: false
+  defp ensure_loaded?(mod), do: Code.ensure_loaded?(mod)
+
+  ## Evaluator interface
+
+  defp imports_from_env(ctx) do
+    ctx.env.functions ++ ctx.env.macros
+  end
+
+  defp aliases_from_env(ctx) do
+    ctx.env.aliases
+  end
+
+  defp variables_from_binding(hint, ctx) do
+    find_matched_variables(ctx.binding, hint)
+  end
+
+  defp find_matched_variables(binding, var_prefix) do
+    for {var_name, value} <- binding,
+        is_atom(var_name),
+        var_name = Atom.to_string(var_name),
+        String.starts_with?(var_name, var_prefix),
+        do: {var_name, value}
+  end
+
+  defp value_from_binding(ast_node, ctx) do
+    with {var, map_key_path} <- extract_from_ast(ast_node, []) do
+      traverse_binding(ctx.binding, var, map_key_path)
+    else
+      _ -> :error
+    end
+  end
+
+  defp traverse_binding(binding, var_name, map_key_path) do
+    accumulator = Keyword.fetch(binding, var_name)
+
+    Enum.reduce(map_key_path, accumulator, fn
+      key, {:ok, map} when is_map(map) -> Map.fetch(map, key)
+      _key, _acc -> :error
+    end)
+  end
+
+  defp extract_from_ast(var_name, acc) when is_atom(var_name) do
+    {var_name, acc}
+  end
+
+  defp extract_from_ast({var_name, _, nil}, acc) when is_atom(var_name) do
+    {var_name, acc}
+  end
+
+  defp extract_from_ast({{:., _, [ast_node, fun]}, _, []}, acc) when is_atom(fun) do
+    extract_from_ast(ast_node, [fun | acc])
+  end
+
+  defp extract_from_ast(_ast_node, _acc) do
+    :error
+  end
+end

--- a/lib/livebook/completion.ex
+++ b/lib/livebook/completion.ex
@@ -432,8 +432,7 @@ defmodule Livebook.Completion do
   defp format_signatures([], _mod), do: nil
 
   defp format_signatures(signatures, mod) do
-    prefix = mod_to_prefix(mod)
-    Enum.map_join(signatures, "\n", &(prefix <> &1))
+    mod_to_prefix(mod) <> Enum.join(signatures, "\n")
   end
 
   defp mod_to_prefix(mod) do

--- a/lib/livebook/completion.ex
+++ b/lib/livebook/completion.ex
@@ -420,7 +420,7 @@ defmodule Livebook.Completion do
       {:docs_v1, _, _, "text/markdown", _, _, docs} ->
         for {{kind, _, _}, _, _, _, _} = doc <- docs, kind in kinds, do: doc
 
-      {:error, _} ->
+      _ ->
         []
     end
   end

--- a/lib/livebook/completion.ex
+++ b/lib/livebook/completion.ex
@@ -417,7 +417,7 @@ defmodule Livebook.Completion do
 
   defp get_docs(mod, kinds) do
     case Code.fetch_docs(mod) do
-      {:docs_v1, _, _, _, _, _, docs} ->
+      {:docs_v1, _, _, "text/markdown", _, _, docs} ->
         for {{kind, _, _}, _, _, _, _} = doc <- docs, kind in kinds, do: doc
 
       {:error, _} ->
@@ -427,7 +427,7 @@ defmodule Livebook.Completion do
 
   defp get_module_doc_content(mod) do
     case Code.fetch_docs(mod) do
-      {:docs_v1, _, _, _, %{"en" => docstring}, _, _} ->
+      {:docs_v1, _, _, "text/markdown", %{"en" => docstring}, _, _} ->
         docstring
 
       _ ->

--- a/lib/livebook/evaluator.ex
+++ b/lib/livebook/evaluator.ex
@@ -70,9 +70,8 @@ defmodule Livebook.Evaluator do
   * `:file` - file to which the evaluated code belongs. Most importantly,
     this has an impact on the value of `__DIR__`.
   """
-  @spec evaluate_code(t(), pid(), String.t(), ref(), ref(), keyword()) :: :ok
-  def evaluate_code(evaluator, send_to, code, ref, prev_ref \\ :initial, opts \\ [])
-      when ref != :initial do
+  @spec evaluate_code(t(), pid(), String.t(), ref(), ref() | nil, keyword()) :: :ok
+  def evaluate_code(evaluator, send_to, code, ref, prev_ref \\ nil, opts \\ []) when ref != nil do
     GenServer.cast(evaluator, {:evaluate_code, send_to, code, ref, prev_ref, opts})
   end
 
@@ -83,6 +82,18 @@ defmodule Livebook.Evaluator do
   @spec forget_evaluation(t(), ref()) :: :ok
   def forget_evaluation(evaluator, ref) do
     GenServer.cast(evaluator, {:forget_evaluation, ref})
+  end
+
+  @doc """
+  Asynchronously finds completion items matching the given `hint` text.
+
+  If `evaluation_ref` is given, its binding and environment are also
+  used for the completion. Response is sent to the `send_to` process
+  as `{:completion_response, ref, items}`.
+  """
+  @spec request_completion_items(t(), pid(), term(), String.t(), ref() | nil) :: :ok
+  def request_completion_items(evaluator, send_to, ref, hint, evaluation_ref) do
+    GenServer.cast(evaluator, {:request_completion_items, send_to, ref, hint, evaluation_ref})
   end
 
   ## Callbacks
@@ -103,7 +114,7 @@ defmodule Livebook.Evaluator do
     %{
       formatter: formatter,
       io_proxy: io_proxy,
-      contexts: %{initial: initial_context()}
+      contexts: %{}
     }
   end
 
@@ -116,8 +127,7 @@ defmodule Livebook.Evaluator do
   def handle_cast({:evaluate_code, send_to, code, ref, prev_ref, opts}, state) do
     Evaluator.IOProxy.configure(state.io_proxy, send_to, ref)
 
-    context = Map.get(state.contexts, prev_ref, state.contexts.initial)
-
+    context = Map.get_lazy(state.contexts, prev_ref, fn -> initial_context() end)
     file = Keyword.get(opts, :file, "nofile")
     context = put_in(context.env.file, file)
 
@@ -144,6 +154,14 @@ defmodule Livebook.Evaluator do
   def handle_cast({:forget_evaluation, ref}, state) do
     new_state = %{state | contexts: Map.delete(state.contexts, ref)}
     {:noreply, new_state}
+  end
+
+  def handle_cast({:request_completion_items, send_to, ref, hint, evaluation_ref}, state) do
+    context = Map.get_lazy(state.contexts, evaluation_ref, fn -> initial_context() end)
+    items = Livebook.Completion.get_completion_items(hint, context.binding, context.env)
+    send(send_to, {:completion_response, ref, items})
+
+    {:noreply, state}
   end
 
   defp send_evaluation_response(send_to, ref, evaluation_response, formatter) do

--- a/lib/livebook/evaluator.ex
+++ b/lib/livebook/evaluator.ex
@@ -92,7 +92,7 @@ defmodule Livebook.Evaluator do
   as `{:completion_response, ref, items}`.
   """
   @spec request_completion_items(t(), pid(), term(), String.t(), ref() | nil) :: :ok
-  def request_completion_items(evaluator, send_to, ref, hint, evaluation_ref) do
+  def request_completion_items(evaluator, send_to, ref, hint, evaluation_ref \\ nil) do
     GenServer.cast(evaluator, {:request_completion_items, send_to, ref, hint, evaluation_ref})
   end
 

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -23,7 +23,7 @@ defprotocol Livebook.Runtime do
           insert_text: String.t()
         }
 
-  @type completion_item_kind :: :variable | :function | :module | :type
+  @type completion_item_kind :: :function | :module | :type | :variable | :field
 
   @doc """
   Sets the caller as runtime owner.

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -12,6 +12,19 @@ defprotocol Livebook.Runtime do
   """
   @type ref :: term()
 
+  @typedoc """
+  A single completion result.
+  """
+  @type completion_item :: %{
+          label: String.t(),
+          kind: completion_item_kind(),
+          detail: String.t() | nil,
+          documentation: String.t() | nil,
+          insert_text: String.t()
+        }
+
+  @type completion_item_kind :: :variable | :function | :module | :type
+
   @doc """
   Sets the caller as runtime owner.
 
@@ -50,15 +63,8 @@ defprotocol Livebook.Runtime do
   * `:file` - file to which the evaluated code belongs. Most importantly,
     this has an impact on the value of `__DIR__`.
   """
-  @spec evaluate_code(t(), String.t(), ref(), ref(), ref(), keyword()) :: :ok
-  def evaluate_code(
-        runtime,
-        code,
-        container_ref,
-        evaluation_ref,
-        prev_evaluation_ref \\ :initial,
-        opts \\ []
-      )
+  @spec evaluate_code(t(), String.t(), ref(), ref(), ref() | nil, keyword()) :: :ok
+  def evaluate_code(runtime, code, container_ref, evaluation_ref, prev_evaluation_ref, opts \\ [])
 
   @doc """
   Disposes of evaluation identified by the given ref.
@@ -76,4 +82,24 @@ defprotocol Livebook.Runtime do
   """
   @spec drop_container(t(), ref()) :: :ok
   def drop_container(runtime, container_ref)
+
+  @doc """
+  Asynchronously finds completion items matching the given `hint` text.
+
+  The given `{container_ref, evaluation_ref}` pair idenfities an evaluation,
+  which bindings and environment are used to provide a more relevant completion results.
+  If there's no appropriate evaluation, `nil` refs can be provided.
+
+  Completion response is sent to the `send_to` process as `{:completion_response, ref, items}`,
+  where `items` is a list of `Livebook.Runtime.completion_item()`.
+  """
+  @spec request_completion_items(t(), pid(), term(), String.t(), ref() | nil, ref() | nil) :: :ok
+  def request_completion_items(
+        runtime,
+        send_to,
+        ref,
+        hint,
+        container_ref,
+        evaluation_ref
+      )
 end

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -54,7 +54,7 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
         code,
         container_ref,
         evaluation_ref,
-        prev_evaluation_ref \\ :initial,
+        prev_evaluation_ref,
         opts \\ []
       ) do
     ErlDist.Manager.evaluate_code(
@@ -73,5 +73,16 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
 
   def drop_container(runtime, container_ref) do
     ErlDist.Manager.drop_container(runtime.node, container_ref)
+  end
+
+  def request_completion_items(runtime, send_to, ref, hint, container_ref, evaluation_ref) do
+    ErlDist.Manager.request_completion_items(
+      runtime.node,
+      send_to,
+      ref,
+      hint,
+      container_ref,
+      evaluation_ref
+    )
   end
 end

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -79,7 +79,7 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.ElixirStandalone do
         code,
         container_ref,
         evaluation_ref,
-        prev_evaluation_ref \\ :initial,
+        prev_evaluation_ref,
         opts \\ []
       ) do
     ErlDist.Manager.evaluate_code(
@@ -98,5 +98,16 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.ElixirStandalone do
 
   def drop_container(runtime, container_ref) do
     ErlDist.Manager.drop_container(runtime.node, container_ref)
+  end
+
+  def request_completion_items(runtime, send_to, ref, hint, container_ref, evaluation_ref) do
+    ErlDist.Manager.request_completion_items(
+      runtime.node,
+      send_to,
+      ref,
+      hint,
+      container_ref,
+      evaluation_ref
+    )
   end
 end

--- a/lib/livebook/runtime/erl_dist.ex
+++ b/lib/livebook/runtime/erl_dist.ex
@@ -21,6 +21,7 @@ defmodule Livebook.Runtime.ErlDist do
     Livebook.Evaluator,
     Livebook.Evaluator.IOProxy,
     Livebook.Evaluator.StringFormatter,
+    Livebook.Completion,
     Livebook.Runtime.ErlDist,
     Livebook.Runtime.ErlDist.Manager,
     Livebook.Runtime.ErlDist.EvaluatorSupervisor,

--- a/lib/livebook/runtime/erl_dist/manager.ex
+++ b/lib/livebook/runtime/erl_dist/manager.ex
@@ -54,17 +54,10 @@ defmodule Livebook.Runtime.ErlDist.Manager do
           String.t(),
           Evaluator.ref(),
           Evaluator.ref(),
-          Evaluator.ref(),
+          Evaluator.ref() | nil,
           keyword()
         ) :: :ok
-  def evaluate_code(
-        node,
-        code,
-        container_ref,
-        evaluation_ref,
-        prev_evaluation_ref \\ :initial,
-        opts \\ []
-      ) do
+  def evaluate_code(node, code, container_ref, evaluation_ref, prev_evaluation_ref, opts \\ []) do
     GenServer.cast(
       {@name, node},
       {:evaluate_code, code, container_ref, evaluation_ref, prev_evaluation_ref, opts}
@@ -90,6 +83,31 @@ defmodule Livebook.Runtime.ErlDist.Manager do
   end
 
   @doc """
+  Asynchronously sends completion request for the given `hint` text.
+
+  The completion request is forwarded to `Evaluator` process
+  belonging to the given `container_ref`. If there's not evaluator,
+  there's also no binding and environment, so the completion is handled
+  by a temporary process.
+
+  See `Livebook.Runtime` for more details.
+  """
+  @spec request_completion_items(
+          node(),
+          pid(),
+          term(),
+          String.t(),
+          Evaluator.ref(),
+          Evaluator.ref()
+        ) :: :ok
+  def request_completion_items(node, send_to, ref, hint, container_ref, evaluation_ref) do
+    GenServer.cast(
+      {@name, node},
+      {:request_completion_items, send_to, ref, hint, container_ref, evaluation_ref}
+    )
+  end
+
+  @doc """
   Stops the manager.
 
   This results in all Livebook-related modules being unloaded from this node.
@@ -108,7 +126,7 @@ defmodule Livebook.Runtime.ErlDist.Manager do
     Process.flag(:trap_exit, true)
 
     {:ok, _} = ErlDist.EvaluatorSupervisor.start_link()
-    {:ok, io_forward_gl_pid} = Livebook.Runtime.ErlDist.IOForwardGL.start_link()
+    {:ok, io_forward_gl_pid} = ErlDist.IOForwardGL.start_link()
 
     # Set `ignore_module_conflict` only for the Manager lifetime.
     initial_ignore_module_conflict = Code.compiler_options()[:ignore_module_conflict]
@@ -209,6 +227,25 @@ defmodule Livebook.Runtime.ErlDist.Manager do
 
   def handle_cast({:drop_container, container_ref}, state) do
     state = discard_evaluator(state, container_ref)
+    {:noreply, state}
+  end
+
+  def handle_cast(
+        {:request_completion_items, send_to, ref, hint, container_ref, evaluation_ref},
+        state
+      ) do
+    if evaluator = Map.get(state.evaluators, container_ref) do
+      Evaluator.request_completion_items(evaluator, send_to, ref, hint, evaluation_ref)
+    else
+      # Since there's no evaluator, we may as well get the completion items here.
+      spawn_link(fn ->
+        binding = []
+        env = :elixir.env_for_eval([])
+        items = Livebook.Completion.get_completion_items(hint, binding, env)
+        send(send_to, {:completion_response, ref, items})
+      end)
+    end
+
     {:noreply, state}
   end
 

--- a/lib/livebook/runtime/mix_standalone.ex
+++ b/lib/livebook/runtime/mix_standalone.ex
@@ -118,7 +118,7 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.MixStandalone do
         code,
         container_ref,
         evaluation_ref,
-        prev_evaluation_ref \\ :initial,
+        prev_evaluation_ref,
         opts \\ []
       ) do
     ErlDist.Manager.evaluate_code(
@@ -137,5 +137,16 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.MixStandalone do
 
   def drop_container(runtime, container_ref) do
     ErlDist.Manager.drop_container(runtime.node, container_ref)
+  end
+
+  def request_completion_items(runtime, send_to, ref, hint, container_ref, evaluation_ref) do
+    ErlDist.Manager.request_completion_items(
+      runtime.node,
+      send_to,
+      ref,
+      hint,
+      container_ref,
+      evaluation_ref
+    )
   end
 end

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -641,7 +641,7 @@ defmodule Livebook.Session do
     prev_ref =
       case Notebook.parent_cells_with_section(state.data.notebook, cell.id) do
         [{parent, _} | _] -> parent.id
-        [] -> :initial
+        [] -> nil
       end
 
     file = (state.data.path || "") <> "#cell"

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -1,7 +1,7 @@
 defmodule LivebookWeb.SessionLive do
   use LivebookWeb, :live_view
 
-  alias Livebook.{SessionSupervisor, Session, Delta, Notebook}
+  alias Livebook.{SessionSupervisor, Session, Delta, Notebook, Runtime}
 
   @impl true
   def mount(%{"id" => session_id}, _session, socket) do
@@ -368,6 +368,29 @@ defmodule LivebookWeb.SessionLive do
      )}
   end
 
+  def handle_event("completion_request", %{"hint" => hint, "cell_id" => cell_id}, socket) do
+    data = socket.private.data
+
+    with {:ok, cell, _section} <- Notebook.fetch_cell_and_section(data.notebook, cell_id) do
+      if data.runtime do
+        prev_ref =
+          case Notebook.parent_cells_with_section(data.notebook, cell.id) do
+            [{parent, _} | _] -> parent.id
+            [] -> nil
+          end
+
+        ref = make_ref()
+        Runtime.request_completion_items(data.runtime, self(), ref, hint, :main, prev_ref)
+
+        {:reply, %{"completion_ref" => inspect(ref)}, socket}
+      else
+        {:reply, %{"completion_ref" => nil}, socket}
+      end
+    else
+      _ -> {:noreply, socket}
+    end
+  end
+
   @impl true
   def handle_info({:operation, operation}, socket) do
     case Session.Data.apply_operation(socket.private.data, operation) do
@@ -403,6 +426,11 @@ defmodule LivebookWeb.SessionLive do
      socket
      |> put_flash(:info, "Session has been closed")
      |> push_redirect(to: Routes.home_path(socket, :page))}
+  end
+
+  def handle_info({:completion_response, ref, items}, socket) do
+    payload = %{"completion_ref" => inspect(ref), "items" => items}
+    {:noreply, push_event(socket, "completion_response", payload)}
   end
 
   def handle_info(_message, socket), do: {:noreply, socket}

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -5,6 +5,7 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
     insert_mode: [
       %{seq: ["esc"], desc: "Switch back to navigation mode"},
       %{seq: ["ctrl", "↵"], desc: "Evaluate cell and stay in insert mode"},
+      %{seq: ["tab"], desc: "Autocomplete expression when applicable"},
       %{seq: ["ctrl", "␣"], desc: "Show completion list, use twice for details"}
     ],
     navigation_mode: [
@@ -39,7 +40,7 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
   @impl true
   def render(assigns) do
     ~L"""
-    <div class="p-6 sm:max-w-4xl sm:w-full flex flex-col space-y-3">
+    <div class="p-6 sm:max-w-5xl sm:w-full flex flex-col space-y-3">
       <h3 class="text-2xl font-semibold text-gray-800">
         Keyboard shortcuts
       </h3>

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -4,7 +4,8 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
   @shortcuts %{
     insert_mode: [
       %{seq: ["esc"], desc: "Switch back to navigation mode"},
-      %{seq: ["ctrl", "↵"], desc: "Evaluate cell and stay in insert mode"}
+      %{seq: ["ctrl", "↵"], desc: "Evaluate cell and stay in insert mode"},
+      %{seq: ["ctrl", "␣"], desc: "Show completion list, use twice for details"}
     ],
     navigation_mode: [
       %{seq: ["?"], desc: "Open this help modal"},

--- a/test/livebook/completion_test.exs
+++ b/test/livebook/completion_test.exs
@@ -812,6 +812,7 @@ defmodule Livebook.CompletionTest do
            ] = Completion.get_completion_items("MyList.to_integ", binding, env)
   end
 
+  @tag :erl_docs
   test "complete aliases of Erlang modules" do
     {binding, env} =
       eval do
@@ -827,6 +828,23 @@ defmodule Livebook.CompletionTest do
              %{label: "mapfoldl/3"},
              %{label: "mapfoldr/3"}
            ] = Completion.get_completion_items("EList.map", binding, env)
+
+    assert %{
+             label: "max/1",
+             kind: :function,
+             detail: "lists.max/1",
+             documentation: """
+             Returns the first element of List that compares greater than or equal to all other elements of List.
+
+             ```
+             @spec max(list) :: max
+             when list: [t, ...],
+                  max: t,
+                  t: term()
+             ```\
+             """,
+             insert_text: "max"
+           } in Completion.get_completion_items("EList.", binding, env)
 
     assert [] = Completion.get_completion_items("EList.Invalid", binding, env)
   end

--- a/test/livebook/completion_test.exs
+++ b/test/livebook/completion_test.exs
@@ -631,7 +631,7 @@ defmodule Livebook.CompletionTest do
     {binding, env} =
       eval do
         import Enum
-        import Supervisor, only: [count_children: 1]
+        import System, only: [version: 0]
         import Protocol
       end
 
@@ -642,13 +642,19 @@ defmodule Livebook.CompletionTest do
              %{label: "take_while/2"}
            ] = Completion.get_completion_items("take", binding, env)
 
-    assert [
-             %{label: "count/1"},
-             %{label: "count/2"},
-             %{label: "count_children/1"},
-             %{label: "count_until/2"},
-             %{label: "count_until/3"}
-           ] = Completion.get_completion_items("count", binding, env)
+    assert %{
+             label: "version/0",
+             kind: :function,
+             detail: "System.version()",
+             documentation: """
+             Elixir version information.
+
+             ```
+             @spec version() :: String.t()
+             ```\
+             """,
+             insert_text: "version"
+           } in Completion.get_completion_items("v", binding, env)
 
     assert [
              %{label: "derive/2"},

--- a/test/livebook/completion_test.exs
+++ b/test/livebook/completion_test.exs
@@ -827,6 +827,8 @@ defmodule Livebook.CompletionTest do
              %{label: "mapfoldl/3"},
              %{label: "mapfoldr/3"}
            ] = Completion.get_completion_items("EList.map", binding, env)
+
+    assert [] = Completion.get_completion_items("EList.Invalid", binding, env)
   end
 
   test "completion for functions added when compiled module is reloaded" do

--- a/test/livebook/completion_test.exs
+++ b/test/livebook/completion_test.exs
@@ -422,22 +422,22 @@ defmodule Livebook.CompletionTest do
     assert [
              %{
                label: "bar_1",
-               kind: :variable,
-               detail: "variable",
+               kind: :field,
+               detail: "field",
                documentation: ~s{```\n~r/pattern/\n```},
                insert_text: "bar_1"
              },
              %{
                label: "bar_2",
-               kind: :variable,
-               detail: "variable",
+               kind: :field,
+               detail: "field",
                documentation: ~s{```\ntrue\n```},
                insert_text: "bar_2"
              },
              %{
                label: "foo",
-               kind: :variable,
-               detail: "variable",
+               kind: :field,
+               detail: "field",
                documentation: ~s{```\n1\n```},
                insert_text: "foo"
              }
@@ -446,8 +446,8 @@ defmodule Livebook.CompletionTest do
     assert [
              %{
                label: "foo",
-               kind: :variable,
-               detail: "variable",
+               kind: :field,
+               detail: "field",
                documentation: ~s{```\n1\n```},
                insert_text: "foo"
              }
@@ -472,8 +472,8 @@ defmodule Livebook.CompletionTest do
     assert [
              %{
                label: "nested",
-               kind: :variable,
-               detail: "variable",
+               kind: :field,
+               detail: "field",
                documentation: """
                ```
                %{
@@ -493,8 +493,8 @@ defmodule Livebook.CompletionTest do
     assert [
              %{
                label: "foo",
-               kind: :variable,
-               detail: "variable",
+               kind: :field,
+               detail: "field",
                documentation: ~s{```\n1\n```},
                insert_text: "foo"
              }

--- a/test/livebook/completion_test.exs
+++ b/test/livebook/completion_test.exs
@@ -1,0 +1,857 @@
+defmodule Livebook.CompletionTest.Utils do
+  @moduledoc false
+
+  @doc """
+  Returns `{binding, env}` resulting from evaluating
+  the given block of code in a fresh context.
+  """
+  defmacro eval(do: block) do
+    binding = []
+    env = :elixir.env_for_eval([])
+    {_, binding, env} = :elixir.eval_quoted(block, binding, env)
+
+    quote do
+      {unquote(Macro.escape(binding)), unquote(Macro.escape(env))}
+    end
+  end
+end
+
+defmodule Livebook.CompletionTest do
+  use ExUnit.Case, async: true
+
+  import Livebook.CompletionTest.Utils
+
+  alias Livebook.Completion
+
+  test "Erlang module completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "zlib",
+               kind: :module,
+               detail: "module",
+               documentation: nil,
+               insert_text: "zlib"
+             }
+           ] = Completion.get_completion_items(":zl", binding, env)
+  end
+
+  test "Erlang module no completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [] = Completion.get_completion_items(":unknown", binding, env)
+  end
+
+  test "Erlang module multiple values completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "user",
+               kind: :module,
+               detail: "module",
+               documentation: nil,
+               insert_text: "user"
+             },
+             %{
+               label: "user_drv",
+               kind: :module,
+               detail: "module",
+               documentation: nil,
+               insert_text: "user_drv"
+             },
+             %{
+               label: "user_sup",
+               kind: :module,
+               detail: "module",
+               documentation: nil,
+               insert_text: "user_sup"
+             }
+           ] = Completion.get_completion_items(":user", binding, env)
+  end
+
+  test "Erlang root completion" do
+    {binding, env} = eval(do: nil)
+
+    assert %{
+             label: "lists",
+             kind: :module,
+             detail: "module",
+             documentation: nil,
+             insert_text: "lists"
+           } in Completion.get_completion_items(":", binding, env)
+  end
+
+  test "Elixir proxy" do
+    {binding, env} = eval(do: nil)
+
+    assert %{
+             label: "Elixir",
+             kind: :module,
+             detail: "module",
+             documentation: nil,
+             insert_text: "Elixir"
+           } in Completion.get_completion_items("E", binding, env)
+  end
+
+  test "Elixir module completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "Enum",
+               kind: :module,
+               detail: "module",
+               documentation: "Provides a set of algorithms to work with enumerables.",
+               insert_text: "Enum"
+             },
+             %{
+               label: "Enumerable",
+               kind: :module,
+               detail: "module",
+               documentation: "Enumerable protocol used by `Enum` and `Stream` modules.",
+               insert_text: "Enumerable"
+             }
+           ] = Completion.get_completion_items("En", binding, env)
+
+    assert [
+             %{
+               label: "Enumerable",
+               kind: :module,
+               detail: "module",
+               documentation: "Enumerable protocol used by `Enum` and `Stream` modules.",
+               insert_text: "Enumerable"
+             }
+           ] = Completion.get_completion_items("Enumera", binding, env)
+  end
+
+  test "Elixir type completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "from/0",
+               kind: :type,
+               detail: "typespec",
+               documentation: "Tuple describing the client of a call request.",
+               insert_text: "from"
+             }
+           ] = Completion.get_completion_items("GenServer.fr", binding, env)
+
+    assert [
+             %{
+               label: "name/0",
+               kind: :type,
+               detail: "typespec",
+               documentation: nil,
+               insert_text: "name"
+             },
+             %{
+               label: "name_all/0",
+               kind: :type,
+               detail: "typespec",
+               documentation: nil,
+               insert_text: "name_all"
+             }
+           ] = Completion.get_completion_items(":file.nam", binding, env)
+  end
+
+  test "Elixir completion with self" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "Enumerable",
+               kind: :module,
+               detail: "module",
+               documentation: "Enumerable protocol used by `Enum` and `Stream` modules.",
+               insert_text: "Enumerable"
+             }
+           ] = Completion.get_completion_items("Enumerable", binding, env)
+  end
+
+  test "Elixir completion on modules from load path" do
+    {binding, env} = eval(do: nil)
+
+    assert %{
+             label: "Jason",
+             kind: :module,
+             detail: "module",
+             documentation: "A blazing fast JSON parser and generator in pure Elixir.",
+             insert_text: "Jason"
+           } in Completion.get_completion_items("Jas", binding, env)
+  end
+
+  test "Elixir no completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [] = Completion.get_completion_items(".", binding, env)
+    assert [] = Completion.get_completion_items("Xyz", binding, env)
+    assert [] = Completion.get_completion_items("x.Foo", binding, env)
+    assert [] = Completion.get_completion_items("x.Foo.get_by", binding, env)
+  end
+
+  test "Elixir root submodule completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "Access",
+               kind: :module,
+               detail: "module",
+               documentation: "Key-based access to data structures.",
+               insert_text: "Access"
+             }
+           ] = Completion.get_completion_items("Elixir.Acce", binding, env)
+  end
+
+  test "Elixir submodule completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "ANSI",
+               kind: :module,
+               detail: "module",
+               documentation: "Functionality to render ANSI escape sequences.",
+               insert_text: "ANSI"
+             }
+           ] = Completion.get_completion_items("IO.AN", binding, env)
+  end
+
+  test "Elixir submodule no completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [] = Completion.get_completion_items("IEx.Xyz", binding, env)
+  end
+
+  test "Elixir function completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "version/0",
+               kind: :function,
+               detail: "System.version()",
+               documentation: """
+               Elixir version information.
+
+               ```
+               @spec version() :: String.t()
+               ```\
+               """,
+               insert_text: "version"
+             }
+           ] = Completion.get_completion_items("System.ve", binding, env)
+  end
+
+  test "Erlang function completion" do
+    {binding, env} = eval(do: nil)
+
+    assert %{
+             label: "gzip/1",
+             kind: :function,
+             detail: nil,
+             documentation: """
+             ```
+             @spec gzip(data) :: compressed
+             when data: iodata(),
+                  compressed: binary()
+             ```\
+             """,
+             insert_text: "gzip"
+           } in Completion.get_completion_items(":zlib.gz", binding, env)
+  end
+
+  test "function completion with arity" do
+    {binding, env} = eval(do: nil)
+
+    assert %{
+             label: "concat/1",
+             kind: :function,
+             detail: "Enum.concat(enumerables)",
+             documentation: """
+             Given an enumerable of enumerables, concatenates the `enumerables` into
+             a single list.
+
+             ```
+             @spec concat(t()) :: t()
+             ```\
+             """,
+             insert_text: "concat"
+           } in Completion.get_completion_items("Enum.concat/", binding, env)
+  end
+
+  test "function completion same name with different arities" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "concat/1",
+               kind: :function,
+               detail: "Enum.concat(enumerables)",
+               documentation: """
+               Given an enumerable of enumerables, concatenates the `enumerables` into
+               a single list.
+
+               ```
+               @spec concat(t()) :: t()
+               ```\
+               """,
+               insert_text: "concat"
+             },
+             %{
+               label: "concat/2",
+               kind: :function,
+               detail: "Enum.concat(left, right)",
+               documentation: """
+               Concatenates the enumerable on the `right` with the enumerable on the
+               `left`.
+
+               ```
+               @spec concat(t(), t()) :: t()
+               ```\
+               """,
+               insert_text: "concat"
+             }
+           ] = Completion.get_completion_items("Enum.concat", binding, env)
+  end
+
+  test "function completion when has default args then documentation all arities have docs" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "join/1",
+               kind: :function,
+               detail: ~S{Enum.join(enumerable, joiner \\ "")},
+               documentation: """
+               Joins the given `enumerable` into a string using `joiner` as a
+               separator.
+
+               ```
+               @spec join(t(), String.t()) ::
+                 String.t()
+               ```\
+               """,
+               insert_text: "join"
+             },
+             %{
+               label: "join/2",
+               kind: :function,
+               detail: ~S{Enum.join(enumerable, joiner \\ "")},
+               documentation: """
+               Joins the given `enumerable` into a string using `joiner` as a
+               separator.
+
+               ```
+               @spec join(t(), String.t()) ::
+                 String.t()
+               ```\
+               """,
+               insert_text: "join"
+             }
+           ] = Completion.get_completion_items("Enum.jo", binding, env)
+  end
+
+  test "function completion using a variable bound to a module" do
+    {binding, env} =
+      eval do
+        mod = System
+      end
+
+    assert [
+             %{
+               label: "version/0",
+               kind: :function,
+               detail: "System.version()",
+               documentation: """
+               Elixir version information.
+
+               ```
+               @spec version() :: String.t()
+               ```\
+               """,
+               insert_text: "version"
+             }
+           ] = Completion.get_completion_items("mod.ve", binding, env)
+  end
+
+  test "map atom key completion" do
+    {binding, env} =
+      eval do
+        map = %{
+          foo: 1,
+          bar_1: ~r/pattern/,
+          bar_2: true
+        }
+      end
+
+    assert [
+             %{
+               label: "bar_1",
+               kind: :variable,
+               detail: "variable",
+               documentation: ~s{```\n~r/pattern/\n```},
+               insert_text: "bar_1"
+             },
+             %{
+               label: "bar_2",
+               kind: :variable,
+               detail: "variable",
+               documentation: ~s{```\ntrue\n```},
+               insert_text: "bar_2"
+             },
+             %{
+               label: "foo",
+               kind: :variable,
+               detail: "variable",
+               documentation: ~s{```\n1\n```},
+               insert_text: "foo"
+             }
+           ] = Completion.get_completion_items("map.", binding, env)
+
+    assert [
+             %{
+               label: "foo",
+               kind: :variable,
+               detail: "variable",
+               documentation: ~s{```\n1\n```},
+               insert_text: "foo"
+             }
+           ] = Completion.get_completion_items("map.f", binding, env)
+  end
+
+  test "nested map atom key completion" do
+    {binding, env} =
+      eval do
+        map = %{
+          nested: %{
+            deeply: %{
+              foo: 1,
+              bar_1: 23,
+              bar_2: 14,
+              mod: System
+            }
+          }
+        }
+      end
+
+    assert [
+             %{
+               label: "nested",
+               kind: :variable,
+               detail: "variable",
+               documentation: """
+               ```
+               %{
+                 deeply: %{
+                   bar_1: 23,
+                   bar_2: 14,
+                   foo: 1,
+                   mod: System
+                 }
+               }
+               ```\
+               """,
+               insert_text: "nested"
+             }
+           ] = Completion.get_completion_items("map.nest", binding, env)
+
+    assert [
+             %{
+               label: "foo",
+               kind: :variable,
+               detail: "variable",
+               documentation: ~s{```\n1\n```},
+               insert_text: "foo"
+             }
+           ] = Completion.get_completion_items("map.nested.deeply.f", binding, env)
+
+    assert [
+             %{
+               label: "version/0",
+               kind: :function,
+               detail: "System.version()",
+               documentation: """
+               Elixir version information.
+
+               ```
+               @spec version() :: String.t()
+               ```\
+               """,
+               insert_text: "version"
+             }
+           ] = Completion.get_completion_items("map.nested.deeply.mod.ve", binding, env)
+
+    assert [] = Completion.get_completion_items("map.non.existent", binding, env)
+  end
+
+  test "map string key completion is not supported" do
+    {binding, env} =
+      eval do
+        map = %{"foo" => 1}
+      end
+
+    assert [] = Completion.get_completion_items("map.f", binding, env)
+  end
+
+  test "autocompletion off a bound variable only works for modules and maps" do
+    {binding, env} =
+      eval do
+        num = 5
+        map = %{nested: %{num: 23}}
+      end
+
+    assert [] = Completion.get_completion_items("num.print", binding, env)
+    assert [] = Completion.get_completion_items("map.nested.num.f", binding, env)
+  end
+
+  test "autocompletion using access syntax does is not supported" do
+    {binding, env} =
+      eval do
+        map = %{nested: %{deeply: %{num: 23}}}
+      end
+
+    assert [] = Completion.get_completion_items("map[:nested][:deeply].n", binding, env)
+    assert [] = Completion.get_completion_items("map[:nested].deeply.n", binding, env)
+    assert [] = Completion.get_completion_items("map.nested.[:deeply].n", binding, env)
+  end
+
+  test "macro completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "is_nil/1",
+               kind: :function,
+               detail: "Kernel.is_nil(term)",
+               documentation: "Returns `true` if `term` is `nil`, `false` otherwise.",
+               insert_text: "is_nil"
+             }
+           ] = Completion.get_completion_items("Kernel.is_ni", binding, env)
+  end
+
+  test "special forms completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "quote/2",
+               kind: :function,
+               detail: "Kernel.SpecialForms.quote(opts, block)",
+               documentation: "Gets the representation of any expression.",
+               insert_text: "quote"
+             }
+           ] = Completion.get_completion_items("quot", binding, env)
+  end
+
+  test "kernel import completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{
+               label: "put_in/2",
+               kind: :function,
+               detail: "Kernel.put_in(path, value)",
+               documentation: "Puts a value in a nested structure via the given `path`.",
+               insert_text: "put_in"
+             },
+             %{
+               label: "put_in/3",
+               kind: :function,
+               detail: "Kernel.put_in(data, keys, value)",
+               documentation: """
+               Puts a value in a nested structure.
+
+               ```
+               @spec put_in(
+                 Access.t(),
+                 [term(), ...],
+                 term()
+               ) :: Access.t()
+               ```\
+               """,
+               insert_text: "put_in"
+             }
+           ] = Completion.get_completion_items("put_i", binding, env)
+  end
+
+  test "variable name completion" do
+    {binding, env} =
+      eval do
+        number = 3
+        numbats = ["numbat", "numbat"]
+        nothing = nil
+      end
+
+    assert [
+             %{
+               label: "numbats",
+               kind: :variable,
+               detail: "variable",
+               documentation: ~s{```\n["numbat", "numbat"]\n```},
+               insert_text: "numbats"
+             }
+           ] = Completion.get_completion_items("numba", binding, env)
+
+    assert [
+             %{
+               label: "numbats",
+               kind: :variable,
+               detail: "variable",
+               documentation: ~s{```\n["numbat", "numbat"]\n```},
+               insert_text: "numbats"
+             },
+             %{
+               label: "number",
+               kind: :variable,
+               detail: "variable",
+               documentation: ~s{```\n3\n```},
+               insert_text: "number"
+             }
+           ] = Completion.get_completion_items("num", binding, env)
+
+    assert [
+             %{
+               label: "nothing",
+               kind: :variable,
+               detail: "variable",
+               documentation: ~s{```\nnil\n```},
+               insert_text: "nothing"
+             },
+             %{label: "node/0"},
+             %{label: "node/1"},
+             %{label: "not/1"}
+           ] = Completion.get_completion_items("no", binding, env)
+  end
+
+  test "completion of manually imported functions and macros" do
+    {binding, env} =
+      eval do
+        import Enum
+        import Supervisor, only: [count_children: 1]
+        import Protocol
+      end
+
+    assert [
+             %{label: "take/2"},
+             %{label: "take_every/2"},
+             %{label: "take_random/2"},
+             %{label: "take_while/2"}
+           ] = Completion.get_completion_items("take", binding, env)
+
+    assert [
+             %{label: "count/1"},
+             %{label: "count/2"},
+             %{label: "count_children/1"},
+             %{label: "count_until/2"},
+             %{label: "count_until/3"}
+           ] = Completion.get_completion_items("count", binding, env)
+
+    assert [
+             %{label: "derive/2"},
+             %{label: "derive/3"}
+           ] = Completion.get_completion_items("der", binding, env)
+  end
+
+  test "ignores quoted variables when performing variable completion" do
+    {binding, env} =
+      eval do
+        quote do
+          var!(my_var_1, Elixir) = 1
+        end
+
+        my_var_2 = 2
+      end
+
+    assert [
+             %{label: "my_var_2"}
+           ] = Completion.get_completion_items("my_var", binding, env)
+  end
+
+  test "completion inside expression" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{label: "Enum"},
+             %{label: "Enumerable"}
+           ] = Completion.get_completion_items("1 En", binding, env)
+
+    assert [
+             %{label: "Enum"},
+             %{label: "Enumerable"}
+           ] = Completion.get_completion_items("foo(En", binding, env)
+
+    assert [
+             %{label: "Enum"},
+             %{label: "Enumerable"}
+           ] = Completion.get_completion_items("Test En", binding, env)
+
+    assert [
+             %{label: "Enum"},
+             %{label: "Enumerable"}
+           ] = Completion.get_completion_items("foo(x,En", binding, env)
+
+    assert [
+             %{label: "Enum"},
+             %{label: "Enumerable"}
+           ] = Completion.get_completion_items("[En", binding, env)
+
+    assert [
+             %{label: "Enum"},
+             %{label: "Enumerable"}
+           ] = Completion.get_completion_items("{En", binding, env)
+  end
+
+  test "ampersand completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{label: "Enum"},
+             %{label: "Enumerable"}
+           ] = Completion.get_completion_items("&En", binding, env)
+
+    assert [
+             %{label: "all?/1"},
+             %{label: "all?/2"}
+           ] = Completion.get_completion_items("&Enum.al", binding, env)
+
+    assert [
+             %{label: "all?/1"},
+             %{label: "all?/2"}
+           ] = Completion.get_completion_items("f = &Enum.al", binding, env)
+  end
+
+  test "negation operator completion" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{label: "is_binary/1"}
+           ] = Completion.get_completion_items("!is_bin", binding, env)
+  end
+
+  test "pin operator completion" do
+    {binding, env} =
+      eval do
+        my_variable = 2
+      end
+
+    assert [
+             %{label: "my_variable"}
+           ] = Completion.get_completion_items("^my_va", binding, env)
+  end
+
+  defmodule SublevelTest.LevelA.LevelB do
+  end
+
+  test "Elixir completion sublevel" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{label: "LevelA"}
+           ] =
+             Completion.get_completion_items(
+               "Livebook.CompletionTest.SublevelTest.",
+               binding,
+               env
+             )
+  end
+
+  test "complete aliases of Elixir modules" do
+    {binding, env} =
+      eval do
+        alias List, as: MyList
+      end
+
+    assert [
+             %{label: "MyList"}
+           ] = Completion.get_completion_items("MyL", binding, env)
+
+    assert [
+             %{label: "to_integer/1"},
+             %{label: "to_integer/2"}
+           ] = Completion.get_completion_items("MyList.to_integ", binding, env)
+  end
+
+  test "complete aliases of Erlang modules" do
+    {binding, env} =
+      eval do
+        alias :lists, as: EList
+      end
+
+    assert [
+             %{label: "EList"}
+           ] = Completion.get_completion_items("EL", binding, env)
+
+    assert [
+             %{label: "map/2"},
+             %{label: "mapfoldl/3"},
+             %{label: "mapfoldr/3"}
+           ] = Completion.get_completion_items("EList.map", binding, env)
+  end
+
+  test "completion for functions added when compiled module is reloaded" do
+    {binding, env} = eval(do: nil)
+
+    {:module, _, bytecode, _} =
+      defmodule Sample do
+        def foo(), do: 0
+      end
+
+    assert [
+             %{label: "foo/0"}
+           ] = Completion.get_completion_items("Livebook.CompletionTest.Sample.foo", binding, env)
+
+    Code.compiler_options(ignore_module_conflict: true)
+
+    defmodule Sample do
+      def foo(), do: 0
+      def foobar(), do: 0
+    end
+
+    assert [
+             %{label: "foo/0"},
+             %{label: "foobar/0"}
+           ] = Completion.get_completion_items("Livebook.CompletionTest.Sample.foo", binding, env)
+  after
+    Code.compiler_options(ignore_module_conflict: false)
+    :code.purge(Sample)
+    :code.delete(Sample)
+  end
+
+  defmodule MyStruct do
+    defstruct [:my_val]
+  end
+
+  test "completion for struct names" do
+    {binding, env} = eval(do: nil)
+
+    assert [
+             %{label: "MyStruct"}
+           ] = Completion.get_completion_items("Livebook.CompletionTest.MyStr", binding, env)
+  end
+
+  test "completion for struct keys" do
+    {binding, env} =
+      eval do
+        struct = %Livebook.CompletionTest.MyStruct{}
+      end
+
+    assert [
+             %{label: "my_val"}
+           ] = Completion.get_completion_items("struct.my", binding, env)
+  end
+
+  test "ignore invalid Elixir module literals" do
+    {binding, env} = eval(do: nil)
+
+    defmodule(:"Elixir.Livebook.CompletionTest.Unicodé", do: nil)
+
+    assert [] = Completion.get_completion_items("Livebook.CompletionTest.Unicod", binding, env)
+  after
+    :code.purge(:"Elixir.Livebook.CompletionTest.Unicodé")
+    :code.delete(:"Elixir.Livebook.CompletionTest.Unicodé")
+  end
+end

--- a/test/livebook/completion_test.exs
+++ b/test/livebook/completion_test.exs
@@ -23,6 +23,28 @@ defmodule Livebook.CompletionTest do
 
   alias Livebook.Completion
 
+  test "completion when no hint given" do
+    {binding, env} = eval(do: nil)
+
+    length_item = %{
+      label: "length/1",
+      kind: :function,
+      detail: "Kernel.length(list)",
+      documentation: """
+      Returns the length of `list`.
+
+      ```
+      @spec length(list()) ::
+        non_neg_integer()
+      ```\
+      """,
+      insert_text: "length"
+    }
+
+    assert length_item in Completion.get_completion_items("", binding, env)
+    assert length_item in Completion.get_completion_items("Enum.map(list, ", binding, env)
+  end
+
   test "Erlang module completion" do
     {binding, env} = eval(do: nil)
 
@@ -74,13 +96,16 @@ defmodule Livebook.CompletionTest do
   test "Erlang root completion" do
     {binding, env} = eval(do: nil)
 
-    assert %{
-             label: "lists",
-             kind: :module,
-             detail: "module",
-             documentation: nil,
-             insert_text: "lists"
-           } in Completion.get_completion_items(":", binding, env)
+    lists_item = %{
+      label: "lists",
+      kind: :module,
+      detail: "module",
+      documentation: nil,
+      insert_text: "lists"
+    }
+
+    assert lists_item in Completion.get_completion_items(":", binding, env)
+    assert lists_item in Completion.get_completion_items("  :", binding, env)
   end
 
   test "Elixir proxy" do

--- a/test/livebook/completion_test.exs
+++ b/test/livebook/completion_test.exs
@@ -45,6 +45,7 @@ defmodule Livebook.CompletionTest do
     assert length_item in Completion.get_completion_items("Enum.map(list, ", binding, env)
   end
 
+  @tag :erl_docs
   test "Erlang module completion" do
     {binding, env} = eval(do: nil)
 
@@ -53,7 +54,8 @@ defmodule Livebook.CompletionTest do
                label: "zlib",
                kind: :module,
                detail: "module",
-               documentation: nil,
+               documentation:
+                 "This module provides an API for the zlib library (www.zlib.net). It is used to compress and decompress data. The data format is described by RFC 1950, RFC 1951, and RFC 1952.",
                insert_text: "zlib"
              }
            ] = Completion.get_completion_items(":zl", binding, env)
@@ -73,26 +75,27 @@ defmodule Livebook.CompletionTest do
                label: "user",
                kind: :module,
                detail: "module",
-               documentation: nil,
+               documentation: _user_doc,
                insert_text: "user"
              },
              %{
                label: "user_drv",
                kind: :module,
                detail: "module",
-               documentation: nil,
+               documentation: _user_drv_doc,
                insert_text: "user_drv"
              },
              %{
                label: "user_sup",
                kind: :module,
                detail: "module",
-               documentation: nil,
+               documentation: _user_sup_doc,
                insert_text: "user_sup"
              }
            ] = Completion.get_completion_items(":user", binding, env)
   end
 
+  @tag :erl_docs
   test "Erlang root completion" do
     {binding, env} = eval(do: nil)
 
@@ -100,7 +103,7 @@ defmodule Livebook.CompletionTest do
       label: "lists",
       kind: :module,
       detail: "module",
-      documentation: nil,
+      documentation: "This module contains functions for list processing.",
       insert_text: "lists"
     }
 
@@ -169,14 +172,14 @@ defmodule Livebook.CompletionTest do
                label: "name/0",
                kind: :type,
                detail: "typespec",
-               documentation: nil,
+               documentation: _name_doc,
                insert_text: "name"
              },
              %{
                label: "name_all/0",
                kind: :type,
                detail: "typespec",
-               documentation: nil,
+               documentation: _name_all_doc,
                insert_text: "name_all"
              }
            ] = Completion.get_completion_items(":file.nam", binding, env)
@@ -271,14 +274,17 @@ defmodule Livebook.CompletionTest do
            ] = Completion.get_completion_items("System.ve", binding, env)
   end
 
+  @tag :erl_docs
   test "Erlang function completion" do
     {binding, env} = eval(do: nil)
 
     assert %{
              label: "gzip/1",
              kind: :function,
-             detail: nil,
+             detail: "zlib.gzip/1",
              documentation: """
+             Compresses data with gz headers and checksum.
+
              ```
              @spec gzip(data) :: compressed
              when data: iodata(),

--- a/test/livebook/evaluator_test.exs
+++ b/test/livebook/evaluator_test.exs
@@ -139,7 +139,7 @@ defmodule Livebook.EvaluatorTest do
       """
 
       opts = [file: "/path/dir/file"]
-      Evaluator.evaluate_code(evaluator, self(), code, :code_1, :initial, opts)
+      Evaluator.evaluate_code(evaluator, self(), code, :code_1, nil, opts)
 
       assert_receive {:evaluation_response, :code_1, {:ok, "/path/dir"}}
     end

--- a/test/livebook/evaluator_test.exs
+++ b/test/livebook/evaluator_test.exs
@@ -105,7 +105,7 @@ defmodule Livebook.EvaluatorTest do
         # Note: evaluating module definitions is relatively slow, so we use a higher wait timeout.
         assert_receive {:evaluation_response, :code_1,
                         {:error, _kind, _error, ^expected_stacktrace}},
-                       1000
+                       1_000
       end)
     end
 
@@ -159,6 +159,30 @@ defmodule Livebook.EvaluatorTest do
                         {:error, _kind, %CompileError{description: "undefined function x/0"},
                          _stacktrace}}
       end)
+    end
+  end
+
+  describe "request_completion_items/5" do
+    test "sends completion response to the given process", %{evaluator: evaluator} do
+      Evaluator.request_completion_items(evaluator, self(), :comp_ref, "System.ver")
+      assert_receive {:completion_response, :comp_ref, [%{label: "version/0"}]}
+    end
+
+    test "given evaluation reference uses its bindings and env", %{evaluator: evaluator} do
+      code1 = """
+      alias IO.ANSI
+      number = 10
+      """
+
+      Evaluator.evaluate_code(evaluator, self(), code1, :code_1)
+      assert_receive {:evaluation_response, :code_1, _}
+
+      Evaluator.request_completion_items(evaluator, self(), :comp_ref, "num", :code_1)
+      assert_receive {:completion_response, :comp_ref, [%{label: "number"}]}
+
+      Evaluator.request_completion_items(evaluator, self(), :comp_ref, "ANSI.brigh", :code_1)
+
+      assert_receive {:completion_response, :comp_ref, [%{label: "bright/0"}]}
     end
   end
 

--- a/test/livebook/runtime/erl_dist/manager_test.exs
+++ b/test/livebook/runtime/erl_dist/manager_test.exs
@@ -32,7 +32,7 @@ defmodule Livebook.Runtime.ErlDist.ManagerTest do
     test "spawns a new evaluator when necessary" do
       Manager.start()
       Manager.set_owner(node(), self())
-      Manager.evaluate_code(node(), "1 + 1", :container1, :evaluation1)
+      Manager.evaluate_code(node(), "1 + 1", :container1, :evaluation1, nil)
 
       assert_receive {:evaluation_response, :evaluation1, _}
 
@@ -45,8 +45,8 @@ defmodule Livebook.Runtime.ErlDist.ManagerTest do
 
       stderr =
         ExUnit.CaptureIO.capture_io(:stderr, fn ->
-          Manager.evaluate_code(node(), "defmodule Foo do end", :container1, :evaluation1)
-          Manager.evaluate_code(node(), "defmodule Foo do end", :container1, :evaluation2)
+          Manager.evaluate_code(node(), "defmodule Foo do end", :container1, :evaluation1, nil)
+          Manager.evaluate_code(node(), "defmodule Foo do end", :container1, :evaluation2, nil)
 
           assert_receive {:evaluation_response, :evaluation1, _}
           assert_receive {:evaluation_response, :evaluation2, _}
@@ -61,7 +61,7 @@ defmodule Livebook.Runtime.ErlDist.ManagerTest do
       Manager.start()
       Manager.set_owner(node(), self())
 
-      Manager.evaluate_code(node(), ~s{IO.puts(:stderr, "error")}, :container1, :evaluation1)
+      Manager.evaluate_code(node(), ~s{IO.puts(:stderr, "error")}, :container1, :evaluation1, nil)
 
       assert_receive {:evaluation_stdout, :evaluation1, "error\n"}
 
@@ -78,7 +78,7 @@ defmodule Livebook.Runtime.ErlDist.ManagerTest do
     spawn_link(fn -> raise "sad cat" end)
     """
 
-    Manager.evaluate_code(node(), code, :container1, :evaluation1)
+    Manager.evaluate_code(node(), code, :container1, :evaluation1, nil)
 
     assert_receive {:container_down, :container1, message}
     assert message =~ "sad cat"

--- a/test/livebook_web/live/path_select_component_test.exs
+++ b/test/livebook_web/live/path_select_component_test.exs
@@ -1,5 +1,6 @@
 defmodule LivebookWeb.PathSelectComponentTest do
-  use LivebookWeb.ConnCase
+  # Note: we cannot run asynchronously, because we use `File.cd!`
+  use LivebookWeb.ConnCase, async: false
 
   import Phoenix.LiveViewTest
 

--- a/test/support/single_evaluator_runtime.ex
+++ b/test/support/single_evaluator_runtime.ex
@@ -30,7 +30,7 @@ defimpl Livebook.Runtime, for: LivebookTest.Runtime.SingleEvaluator do
         code,
         _container_ref,
         evaluation_ref,
-        prev_evaluation_ref \\ :initial,
+        prev_evaluation_ref,
         opts \\ []
       ) do
     Evaluator.evaluate_code(
@@ -50,4 +50,14 @@ defimpl Livebook.Runtime, for: LivebookTest.Runtime.SingleEvaluator do
   end
 
   def drop_container(_runtime, _container_ref), do: :ok
+
+  def request_completion_items(runtime, send_to, ref, hint, _container_ref, evaluation_ref) do
+    Evaluator.request_completion_items(
+      runtime.evaluator,
+      send_to,
+      ref,
+      hint,
+      evaluation_ref
+    )
+  end
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,6 @@
-ExUnit.start(assert_receive_timeout: 300)
+erl_docs_available? = Code.fetch_docs(:gen_server) != {:error, :chunk_not_found}
+
+exclude = []
+exclude = if erl_docs_available?, do: exclude, else: Keyword.put(exclude, :erl_docs, true)
+
+ExUnit.start(assert_receive_timeout: 300, exclude: exclude)


### PR DESCRIPTION
Closes #47.

Introduces completion for modules, functions, types and variables. Completion hints include signatures, documentation and specs. For variables we also show the inspected value (loosely related to #179).

When it comes to completion there's always room for extending it, but in our case the goal is to provide a reasonably productive subset (rather than implementing/using a language server ^^). One of the reasons is that the we need to dynamically load the necessary code to the node we are connecting to, so we should keep it relatively small.

### Structure

This PR has two relatively independent parts:

#### The completion itself

It's all encapsulated in the `Livebook.Completion` module and tested in `Livebook.CompletionTest`. There we define how `{hint, binding, env}` gets transformed into a list of completion items.

#### Communication

On a high level, we have a new `request_completion` function in the `Runtime` protocol. `Session LV`, upon receiving completion request, sends an asynchronous request to the runtime and returns a unique completion reference to the client. Then it receives `{:completion_response, ref, items}` back from the runtime, and consequently forwards this to the client.

Adding the Erlang Distribution runtimes into the equation, that's how a completion request is forwarded:

```
Session LV -> Runtime.request_completion -> Manager.request_completion -> Evaluator.request_completion
```

Eventually `Evaluator` sends completion response back to the `Session LV` that originated it.

### Usage

![image](https://user-images.githubusercontent.com/17034772/115117155-75cd4200-9f9d-11eb-9f7d-f5534fa47f1f.png)

### Demo

https://user-images.githubusercontent.com/17034772/115117125-533b2900-9f9d-11eb-94a9-a2cf2ccb7388.mp4

