### PR TITLE
Remove assumption about root path

### DIFF
--- a/lib/livebook_web/live/path_select_component.ex
+++ b/lib/livebook_web/live/path_select_component.ex
@@ -121,7 +121,7 @@ defmodule LivebookWeb.PathSelectComponent do
         end)
 
       file_infos =
-        if dir == "/" do
+        if Path.dirname(dir) == dir do
           file_infos
         else
           parent_dir = file_info(dir, "..", basename, running_paths)


### PR DESCRIPTION
This PR addresses how go-to-parent-directory -button is displayed by the PathSelectComponent on Windows systems. 

Prior to the change introduced here, Windows systems would display a go-to-parent-directory -button ("..") even when the user is already in the very root of their drive (such as C:/) and cannot traverse any further up. This PR simply changes the current assumption that root path would always equal to "/", which isn't technically the case on Windows systems where paths start with the drive names.

This issue was brought up in https://github.com/elixir-nx/livebook/issues/204