### PR TITLE
Allow incomplete paths w/o crashing

### DIFF
--- a/lib/livebook_web/live/path_select_component.ex
+++ b/lib/livebook_web/live/path_select_component.ex
@@ -162,7 +162,7 @@ defmodule LivebookWeb.PathSelectComponent do
     if String.ends_with?(path, "/") do
       {path, ""}
     else
-      {Path.dirname(path), Path.basename(path)}
+      {ensure_trailing_slash(Path.dirname(path)), Path.basename(path)}
     end
   end
 


### PR DESCRIPTION
Currently the only way to change a drive on Windows (say, from "C:/" to "D:/") is to use the path select component and to write the drive letter manually. I discovered that when one starts typing a Windows path, such as "D:/", our UI encounters a crash and we get sent back to the initial state, making it difficult (or at least inconvenient) to reach the root of another drive. 

This issue occurs because when we type, we will reach a point where the written path is just `"D:"`, and when we try to call `Path.expand/1` on `"D:"`, we get an error. This PR tries to address this issue by appending a trailing slash to directory names, allowing incomplete path names to exist without crashing the system.

**I'm not quite sure if this is the best way forward**, as we are technically allowing invalid path names to be written here (such as "C:)"), but we'll want to avoid the UI crashing one way or the other regardless. Invalid path names like this do not alter the way the UI behaves, but saves users from typos crashing the UI.