### PR TITLE
Handle a short ANSI reset (ESC[m)

### DIFF
--- a/lib/livebook_web/ansi.ex
+++ b/lib/livebook_web/ansi.ex
@@ -79,6 +79,9 @@ defmodule LivebookWeb.ANSI do
 
   defmodifier(:reset, 0)
 
+  # When the code is missing (i.e., "\e[m"), it is 0 for reset.
+  defmodifier(:reset, "")
+
   @colors [:black, :red, :green, :yellow, :blue, :magenta, :cyan, :white]
 
   for {color, index} <- Enum.with_index(@colors) do

--- a/test/livebook_web/ansi_test.exs
+++ b/test/livebook_web/ansi_test.exs
@@ -18,6 +18,11 @@ defmodule LivebookWeb.ANSITest do
                ANSI.ansi_string_to_html("\e[4mcat\e[0m") |> Phoenix.HTML.safe_to_string()
     end
 
+    test "supports short reset sequence" do
+      assert ~s{<span style="color: var(--ansi-color-blue);">cat</span>} ==
+               ANSI.ansi_string_to_html("\e[34mcat\e[m") |> Phoenix.HTML.safe_to_string()
+    end
+
     test "supports multiple escape codes at the same time" do
       assert ~s{<span style="background-color: var(--ansi-color-red);color: var(--ansi-color-blue);">cat</span>} ==
                ANSI.ansi_string_to_html("\e[34m\e[41mcat\e[0m") |> Phoenix.HTML.safe_to_string()


### PR DESCRIPTION
It's legal to omit the 0 in the ESC[0m sequence to reduce the number of
bytes needed to reset the terminal. See
https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_(Control_Sequence_Introducer)_sequences
and a simple explanation and the cited reference for a more involved
one.
