### PR TITLE
Allow re-ordering of sections 

### DIFF
--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -89,9 +89,9 @@ const Session = {
       handleSectionDeleted(this, sectionId);
     });
 
-    this.handleEvent("section_moved", ({section_id: sectionId }) => {
+    this.handleEvent("section_moved", ({ section_id: sectionId }) => {
       handleSectionMoved(this, sectionId);
-    })
+    });
 
     this.handleEvent("cell_upload", ({ cell_id: cellId, url }) => {
       handleCellUpload(this, cellId, url);
@@ -509,8 +509,8 @@ function handleSectionDeleted(hook, sectionId) {
 }
 
 function handleSectionMoved(hook, sectionId) {
-  if (hook.state.focusedSectionId === sectionId){
-    globalPubSub.broadcast("session", {type: "section_moved", sectionId})
+  if (hook.state.focusedSectionId === sectionId) {
+    globalPubSub.broadcast("session", { type: "section_moved", sectionId });
   }
 }
 

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -89,6 +89,10 @@ const Session = {
       handleSectionDeleted(this, sectionId);
     });
 
+    this.handleEvent("section_moved", ({section_id: sectionId }) => {
+      handleSectionMoved(this, sectionId);
+    })
+
     this.handleEvent("cell_upload", ({ cell_id: cellId, url }) => {
       handleCellUpload(this, cellId, url);
     });
@@ -501,6 +505,12 @@ function handleSectionInserted(hook, sectionId) {
 function handleSectionDeleted(hook, sectionId) {
   if (hook.state.focusedSectionId === sectionId) {
     setFocusedCell(hook, null);
+  }
+}
+
+function handleSectionMoved(hook, sectionId) {
+  if (hook.state.focusedSectionId === sectionId){
+    globalPubSub.broadcast("session", {type: "section_moved", sectionId})
   }
 }
 

--- a/lib/livebook/notebook.ex
+++ b/lib/livebook/notebook.ex
@@ -230,6 +230,28 @@ defmodule Livebook.Notebook do
   end
 
   @doc """
+  Moves section by the given offset.
+  """
+  @spec move_section(t(), Section.id(), integer()) :: t()
+  def move_section(notebook, section_id, offset) do
+    # We first find the index of the given section.
+    # Then we find its' new index from given offset.
+    # Finally, we move the section, and return the new notebook.
+
+    idx =
+      Enum.find_index(notebook.sections, fn
+        section -> section.id == section_id
+      end)
+
+    new_idx = (idx + offset) |> clamp_index(notebook.sections)
+
+    {section, sections} = List.pop_at(notebook.sections, idx)
+    sections = List.insert_at(sections, new_idx, section)
+
+    %{notebook | sections: sections}
+  end
+
+  @doc """
   Returns a list of `{cell, section}` pairs including all Elixir cells in order.
   """
   @spec elixir_cells_with_section(t()) :: list({Cell.t(), Section.t()})

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -145,6 +145,14 @@ defmodule Livebook.Session do
   end
 
   @doc """
+  Asynchronously sends section move request to the server.
+  """
+  @spec move_section(id(), Section.id(), integer()) :: :ok
+  def move_section(session_id, section_id, offset) do
+    GenServer.cast(name(session_id), {:move_section, self(), section_id, offset})
+  end
+
+  @doc """
   Asynchronously sends cell evaluation request to the server.
   """
   @spec queue_cell_evaluation(id(), Cell.id()) :: :ok
@@ -354,6 +362,11 @@ defmodule Livebook.Session do
 
   def handle_cast({:move_cell, client_pid, cell_id, offset}, state) do
     operation = {:move_cell, client_pid, cell_id, offset}
+    {:noreply, handle_operation(state, operation)}
+  end
+
+  def handle_cast({:move_section, client_pid, section_id, offset}, state) do
+    operation = {:move_section, client_pid, section_id, offset}
     {:noreply, handle_operation(state, operation)}
   end
 

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -300,6 +300,13 @@ defmodule LivebookWeb.SessionLive do
     {:noreply, socket}
   end
 
+  def handle_event("move_section", %{"section_id" => section_id, "offset" => offset}, socket) do
+    offset = ensure_integer(offset)
+    Session.move_section(socket.assigns.session_id, section_id, offset)
+
+    {:noreply, socket}
+  end
+
   def handle_event("queue_cell_evaluation", %{"cell_id" => cell_id}, socket) do
     Session.queue_cell_evaluation(socket.assigns.session_id, cell_id)
     {:noreply, socket}

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -17,6 +17,22 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
           <%# ^ Note it's important there's no space between <h2> and </h2>
             because we want the content to exactly match section name. %>
         <div class="flex space-x-2 items-center" data-element="section-actions">
+          <span class="tooltip top" aria-label="Move up">
+            <button class="icon-button"
+              phx-click="move_section"
+              phx-value-section_id="<%= @section_view.id %>"
+              phx-value-offset="-1">
+              <%= remix_icon("arrow-up-s-line", class: "text-xl") %>
+            </button>
+          </span>
+          <span class="tooltip top" aria-label="Move down">
+            <button class="icon-button"
+              phx-click="move_section"
+              phx-value-section_id="<%= @section_view.id %>"
+              phx-value-offset="1">
+              <%= remix_icon("arrow-down-s-line", class: "text-xl") %>
+            </button>
+          </span>
           <span class="tooltip top" aria-label="Delete">
             <button class="icon-button" phx-click="delete_section" phx-value-section_id="<%= @section_view.id %>" tabindex="-1">
               <%= remix_icon("delete-bin-6-line", class: "text-xl") %>

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -430,6 +430,214 @@ defmodule Livebook.Session.DataTest do
     end
   end
 
+describe "apply_operation/2 given :move_section" do
+    test "returns an error given invalid section id" do
+      data = Data.new()
+      operation = {:move_section, self(), "nonexistent", 1}
+      assert :error = Data.apply_operation(data, operation)
+    end
+
+    test "returns an error given no offset" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"}
+          {:insert_section, self(), 1, "s2"}
+        ])
+
+      operation = {:move_section, self(), "s2", 0}
+      assert :error = Data.apply_operation(data, operation)
+    end
+
+    test "given negative offset moves the section and marks relevant cells as stale" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_section, self(), 1, "s2"}
+          # Add cells
+          {:insert_cell, self(), "s1", 0, :elixir, "c1"},
+          {:insert_cell, self(), "s1", 1, :elixir, "c2"},
+          {:insert_cell, self(), "s2", 0, :elixir, "c3"},
+          {:insert_cell, self(), "s2", 1, :elixir, "c4"};
+          # Evaluate cells
+          {:queue_cell_evaluation, self(), "c1"},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:queue_cell_evaluation, self(), "c2"},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}},
+          {:queue_cell_evaluation, self(), "c3"},
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}},
+          {:queue_cell_evaluation, self(), "c4"},
+          {:add_cell_evaluation_response, self(), "c4", {:ok, nil}}
+        ])
+
+      operation = {:move_section, self(), "s2", -1}
+            assert {:ok,
+              %{
+                notebook: %{
+                  sections: [
+                    %{
+                      cells: [%{id: "c3"}, %{id: "c4"}]
+                    },
+                    %{
+                      cells: [%{id: "c1"}, %{id: "c2"}]
+                    }
+                  ]
+                },
+                cell_infos: %{
+                  "c1" => %{validity_status: :stale},
+                  "c2" => %{validity_status: :stale},
+                  "c3" => %{validity_status: :stale},
+                  "c4" => %{validity_status: :stale}
+                }
+              }, []} = Data.apply_operation(data, operation)
+    end
+
+    test "given positive offset moves the section and marks relevant cells as stale" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_section, self(), 1, "s2"}
+          # Add cells
+          {:insert_cell, self(), "s1", 0, :elixir, "c1"},
+          {:insert_cell, self(), "s1", 1, :elixir, "c2"},
+          {:insert_cell, self(), "s2", 0, :elixir, "c3"},
+          {:insert_cell, self(), "s2", 1, :elixir, "c4"};
+          # Evaluate cells
+          {:queue_cell_evaluation, self(), "c1"},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:queue_cell_evaluation, self(), "c2"},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}},
+          {:queue_cell_evaluation, self(), "c3"},
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}},
+          {:queue_cell_evaluation, self(), "c4"},
+          {:add_cell_evaluation_response, self(), "c4", {:ok, nil}}
+        ])
+
+      operation = {:move_section, self(), "s1", 1}
+            assert {:ok,
+              %{
+                notebook: %{
+                  sections: [
+                    %{
+                      cells: [%{id: "c3"}, %{id: "c4"}]
+                    },
+                    %{
+                      cells: [%{id: "c1"}, %{id: "c2"}]
+                    }
+                  ]
+                },
+                cell_infos: %{
+                  "c1" => %{validity_status: :stale},
+                  "c2" => %{validity_status: :stale},
+                  "c3" => %{validity_status: :stale},
+                  "c4" => %{validity_status: :stale}
+                }
+              }, []} = Data.apply_operation(data, operation)
+    end
+
+    test "marks relevant cells in further sections as stale" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_section, self(), 1, "s2"},
+          {:insert_section, self(), 2, "s3"},
+          # Add cells
+          {:insert_cell, self(), "s1", 0, :elixir, "c1"},
+          {:insert_cell, self(), "s2", 1, :elixir, "c2"},
+          {:insert_cell, self(), "s3", 0, :elixir, "c3"},
+          # Evaluate cells
+          {:queue_cell_evaluation, self(), "c1"},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:queue_cell_evaluation, self(), "c2"},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}},
+          {:queue_cell_evaluation, self(), "c3"},
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}}
+        ])
+
+      operation = {:move_section, self(), "s1", 1}
+
+      assert {:ok,
+              %{
+                cell_infos: %{"c3" => %{validity_status: :stale}}
+              }, []} = Data.apply_operation(data, operation)
+    end
+
+    test "moving a section with only markdown cells does not change validity" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_section, self(), 1, "s2"},
+          # Add cells
+          {:insert_cell, self(), "s1", 0, :elixir "c1"},
+          {:insert_cell, self(), "s2", 0, :markdown, "c2"},
+          # Evaluate the Elixir cell
+          {:queue_cell_evaluation, self(), "c1"},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}}
+        ])
+
+      operation = {:move_section, self(), "s2", -1}
+
+      assert {:ok,
+              %{
+                cell_infos: %{
+                  "c1" => %{validity_status: :evaluated}
+                }
+              }, []} = Data.apply_operation(data, operation)
+    end
+
+    test "affected queued cells are unqueued" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_section, self(), 1, "s2"},
+          # Add cells
+          {:insert_cell, self(), "s1", 0, :elixir, "c1"},
+          {:insert_cell, self(), "s2", 0, :elixir, "c2"},
+          # Evaluate the Elixir cell
+          {:queue_cell_evaluation, self(), "c1"},
+          {:queue_cell_evaluation, self(), "c2"}
+        ])
+
+      operation = {:move_section, self(), "s2", -1}
+
+      assert {:ok,
+              %{
+                cell_infos: %{
+                  "c2" => %{evaluation_status: :ready}
+                }
+              }, []} = Data.apply_operation(data, operation)
+    end
+
+    test "does not invalidate cells in moved section if the order of Elixir cells stays the same" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_section, self(), 1, "s2"},
+          {:insert_section, self(), 2, "s3"},
+          {:insert_section, self(), 3, "s4"},
+          # Add cells
+          {:insert_cell, self(), "s1", 0, :elixir, "c1"},
+          {:insert_cell, self(), "s2", 0, :markdown, "c2"},
+          {:insert_cell, self(), "s3", 0, :elixir, "c3"},
+          {:insert_cell, self(), "s4", 0, :markdown, "c4"},
+          # Evaluate cells
+          {:queue_cell_evaluation, self(), "c1"},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:queue_cell_evaluation, self(), "c3"},
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}}
+        ])
+
+      operation = {:move_section, self(), "s4", -1}
+
+      assert {:ok,
+              %{
+                cell_infos: %{
+                  "c1" => %{validity_status: :evaluated},
+                  "c3" => %{validity_status: :evaluated}
+                }
+              }, []} = Data.apply_operation(data, operation)
+    end
+  end
+
   describe "apply_operation/2 given :queue_cell_evaluation" do
     test "returns an error given invalid cell id" do
       data = Data.new()

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -430,7 +430,7 @@ defmodule Livebook.Session.DataTest do
     end
   end
 
-describe "apply_operation/2 given :move_section" do
+  describe "apply_operation/2 given :move_section" do
     test "returns an error given invalid section id" do
       data = Data.new()
       operation = {:move_section, self(), "nonexistent", 1}
@@ -470,7 +470,8 @@ describe "apply_operation/2 given :move_section" do
         ])
 
       operation = {:move_section, self(), "s2", -1}
-            assert {:ok,
+
+      assert {:ok,
               %{
                 notebook: %{
                   sections: [
@@ -513,7 +514,8 @@ describe "apply_operation/2 given :move_section" do
         ])
 
       operation = {:move_section, self(), "s1", 1}
-            assert {:ok,
+
+      assert {:ok,
               %{
                 notebook: %{
                   sections: [

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -440,7 +440,7 @@ describe "apply_operation/2 given :move_section" do
     test "returns an error given no offset" do
       data =
         data_after_operations!([
-          {:insert_section, self(), 0, "s1"}
+          {:insert_section, self(), 0, "s1"},
           {:insert_section, self(), 1, "s2"}
         ])
 
@@ -452,12 +452,12 @@ describe "apply_operation/2 given :move_section" do
       data =
         data_after_operations!([
           {:insert_section, self(), 0, "s1"},
-          {:insert_section, self(), 1, "s2"}
+          {:insert_section, self(), 1, "s2"},
           # Add cells
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:insert_cell, self(), "s2", 0, :elixir, "c3"},
-          {:insert_cell, self(), "s2", 1, :elixir, "c4"};
+          {:insert_cell, self(), "s2", 1, :elixir, "c4"},
           # Evaluate cells
           {:queue_cell_evaluation, self(), "c1"},
           {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
@@ -495,12 +495,12 @@ describe "apply_operation/2 given :move_section" do
       data =
         data_after_operations!([
           {:insert_section, self(), 0, "s1"},
-          {:insert_section, self(), 1, "s2"}
+          {:insert_section, self(), 1, "s2"},
           # Add cells
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:insert_cell, self(), "s2", 0, :elixir, "c3"},
-          {:insert_cell, self(), "s2", 1, :elixir, "c4"};
+          {:insert_cell, self(), "s2", 1, :elixir, "c4"},
           # Evaluate cells
           {:queue_cell_evaluation, self(), "c1"},
           {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
@@ -567,7 +567,7 @@ describe "apply_operation/2 given :move_section" do
           {:insert_section, self(), 0, "s1"},
           {:insert_section, self(), 1, "s2"},
           # Add cells
-          {:insert_cell, self(), "s1", 0, :elixir "c1"},
+          {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:insert_cell, self(), "s2", 0, :markdown, "c2"},
           # Evaluate the Elixir cell
           {:queue_cell_evaluation, self(), "c1"},


### PR DESCRIPTION
Closes #72.

Introduces re-ordering of sections, and implements "Move up" and "Move down" actions for sections, analogous to 
the cell equivalents.

Do note that while I am able to move the section up or down, I was unable to get the notebook to scroll and focus on
the respective section after it has moved. This is probably because my knowledge of javascript is very minimal.

Another feature that could be implemented is to the ability to drag the respective section button in the section list up or down.
However, I avoided implementing this because the javascript involved is beyond my reach.

**Note:** This is the first time I am contributing to opensource (and an elixir project). I would be quite happy to implement any suggestions and changes.