### PR TITLE
Beautify match file selector results

### DIFF
--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -45,13 +45,15 @@
       }
     },
     "../deps/phoenix": {
-      "version": "0.0.1"
+      "version": "1.5.8",
+      "license": "MIT"
     },
     "../deps/phoenix_html": {
-      "version": "0.0.1"
+      "version": "2.14.3"
     },
     "../deps/phoenix_live_view": {
-      "version": "0.0.1"
+      "version": "0.15.4",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -45,15 +45,13 @@
       }
     },
     "../deps/phoenix": {
-      "version": "1.5.8",
-      "license": "MIT"
+      "version": "0.0.1"
     },
     "../deps/phoenix_html": {
-      "version": "2.14.3"
+      "version": "0.0.1"
     },
     "../deps/phoenix_live_view": {
-      "version": "0.15.4",
-      "license": "MIT"
+      "version": "0.0.1"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.12.11",

--- a/lib/livebook_web/live/path_select_component.ex
+++ b/lib/livebook_web/live/path_select_component.ex
@@ -50,15 +50,18 @@ defmodule LivebookWeb.PathSelectComponent do
         <% end %>
       </div>
       <div class="flex-grow -m-1 p-1 overflow-y-auto tiny-scrollbar">
-        <div class="grid grid-cols-4 gap-2">
+        <div class="
+          grid grid-cols-4 gap-2
+          <%= if Enum.any?(list_files(@path, @extnames, @running_paths), fn file -> file.is_filtrate == false end) do%>
+            border-dashed border-b border-gray-200
+          <% end %>
+        ">
           <%= for file <- list_files(@path, @extnames, @running_paths) do %>
             <%= if file.is_filtrate do %>
               <%= render_file(file, @phx_target) %>
             <% end %>
           <% end %>
         </div>
-      </div>
-      <div class="flex-grow -m-1 p-1 overflow-y-auto tiny-scrollbar">
         <div class="grid grid-cols-4 gap-2">
           <%= for file <- list_files(@path, @extnames, @running_paths) do %>
             <%= if not file.is_filtrate do %>

--- a/lib/livebook_web/live/path_select_component.ex
+++ b/lib/livebook_web/live/path_select_component.ex
@@ -51,8 +51,19 @@ defmodule LivebookWeb.PathSelectComponent do
       </div>
       <div class="flex-grow -m-1 p-1 overflow-y-auto tiny-scrollbar">
         <div class="grid grid-cols-4 gap-2">
-          <%= for file <- list_matching_files(@path, @extnames, @running_paths) do %>
-            <%= render_file(file, @phx_target) %>
+          <%= for file <- list_files(@path, @extnames, @running_paths) do %>
+            <%= if file.is_filtrate do %>
+              <%= render_file(file, @phx_target) %>
+            <% end %>
+          <% end %>
+        </div>
+      </div>
+      <div class="flex-grow -m-1 p-1 overflow-y-auto tiny-scrollbar">
+        <div class="grid grid-cols-4 gap-2">
+          <%= for file <- list_files(@path, @extnames, @running_paths) do %>
+            <%= if not file.is_filtrate do %>
+              <%= render_file(file, @phx_target) %>
+            <% end %>
           <% end %>
         </div>
       </div>
@@ -90,6 +101,21 @@ defmodule LivebookWeb.PathSelectComponent do
       </span>
     </button>
     """
+  end
+
+  defp list_files(path, extnames, running_paths) do
+    # Returns files in a directory.
+    # Note: all files are marked as filtrate if none pass filter.
+
+    files = list_matching_files(path, extnames, running_paths)
+
+    all_failed? = files |> Enum.all?(fn file -> file.is_filtrate == false end)
+
+    if all_failed? do
+      for file <- files, do: %{file | is_filtrate: true}
+    else
+      files
+    end
   end
 
   defp list_matching_files(path, extnames, running_paths) do
@@ -145,6 +171,7 @@ defmodule LivebookWeb.PathSelectComponent do
       highlighted: if(String.starts_with?(name, filter), do: filter, else: ""),
       unhighlighted: String.replace_prefix(name, filter, ""),
       path: if(is_dir, do: ensure_trailing_slash(path), else: path),
+      is_filtrate: String.starts_with?(name, filter),
       is_dir: is_dir,
       is_running: path in running_paths
     }

--- a/lib/livebook_web/live/path_select_component.ex
+++ b/lib/livebook_web/live/path_select_component.ex
@@ -64,12 +64,14 @@ defmodule LivebookWeb.PathSelectComponent do
 
   defp file_groups(path, extnames, running_paths) do
     files = list_matching_files(path, extnames, running_paths)
+
     List.delete(
       [
         Enum.filter(files, fn file -> file.highlighted != "" end),
         Enum.filter(files, fn file -> file.highlighted == "" end)
       ],
-    [])
+      []
+    )
   end
 
   defp render_file(file, phx_target) do

--- a/lib/livebook_web/live/path_select_component.ex
+++ b/lib/livebook_web/live/path_select_component.ex
@@ -49,29 +49,27 @@ defmodule LivebookWeb.PathSelectComponent do
           </div>
         <% end %>
       </div>
-      <div class="flex-grow -m-1 p-1 overflow-y-auto tiny-scrollbar">
-        <div class="
-          grid grid-cols-4 gap-2
-          <%= if Enum.any?(list_files(@path, @extnames, @running_paths), fn file -> file.is_filtrate == false end) do%>
-            border-dashed border-b border-gray-200
-          <% end %>
-        ">
-          <%= for file <- list_files(@path, @extnames, @running_paths) do %>
-            <%= if file.is_filtrate do %>
+      <div class="flex-grow -m-1 p-1 overflow-y-auto tiny-scrollbar divide-y divide-grey-200 divide-dashed">
+        <%= for file_group <- file_groups(@path, @extnames, @running_paths) do %>
+          <div class="grid grid-cols-4 gap-2">
+            <%= for file <- file_group do %>
               <%= render_file(file, @phx_target) %>
             <% end %>
-          <% end %>
-        </div>
-        <div class="grid grid-cols-4 gap-2">
-          <%= for file <- list_files(@path, @extnames, @running_paths) do %>
-            <%= if not file.is_filtrate do %>
-              <%= render_file(file, @phx_target) %>
-            <% end %>
-          <% end %>
-        </div>
+          </div>
+        <% end %>
       </div>
     </div>
     """
+  end
+
+  defp file_groups(path, extnames, running_paths) do
+    files = list_matching_files(path, extnames, running_paths)
+    List.delete(
+      [
+        Enum.filter(files, fn file -> file.highlighted != "" end),
+        Enum.filter(files, fn file -> file.highlighted == "" end)
+      ],
+    [])
   end
 
   defp render_file(file, phx_target) do
@@ -104,21 +102,6 @@ defmodule LivebookWeb.PathSelectComponent do
       </span>
     </button>
     """
-  end
-
-  defp list_files(path, extnames, running_paths) do
-    # Returns files in a directory.
-    # Note: all files are marked as filtrate if none pass filter.
-
-    files = list_matching_files(path, extnames, running_paths)
-
-    all_failed? = files |> Enum.all?(fn file -> file.is_filtrate == false end)
-
-    if all_failed? do
-      for file <- files, do: %{file | is_filtrate: true}
-    else
-      files
-    end
   end
 
   defp list_matching_files(path, extnames, running_paths) do


### PR DESCRIPTION
Closes #164

- Makes the filtred files and rest of the files to have a "box"/"container" of its own (in total 2 "boxes")
- Seperates the filtred files from rest of the files with a white space between respective "boxes".

I personally felt that having a big space in between should be enough separate results. 
I also felt that we **should'nt** include the filtred files with the rest of the files.

We could "beautify" it more by making the path go red to indicate that it's failing. Or we could put a line in between the boxes.

In my opinion, right now, the page looks just perfect.

![Screenshot_2021-04-20_16-43-08](https://user-images.githubusercontent.com/67545861/115386962-adcfc180-a1f7-11eb-880b-088351627f87.png)
 