### PR TITLE
Ignore RFC 1468 switch to ASCII code sequence

### DIFF
--- a/test/livebook_web/ansi_test.exs
+++ b/test/livebook_web/ansi_test.exs
@@ -94,5 +94,9 @@ defmodule LivebookWeb.ANSITest do
                ANSI.ansi_string_to_html("cat", renderer: div_renderer)
                |> Phoenix.HTML.safe_to_string()
     end
+
+    test "ignores RFC 1468 switch to ASCII" do
+      assert ~s{cat} == ANSI.ansi_string_to_html("\e(Bcat") |> Phoenix.HTML.safe_to_string()
+    end
   end
 end


### PR DESCRIPTION
This ignores "\e(B" which sometimes shows up even when the other RFC
1468 Japanese character set switch codes aren't used. This also updates
defmodifier so that it can be used with non-CSI escape codes (the
ones that start with '[').
