### PR TITLE
Fix markdown line breaks rendering

### DIFF
--- a/lib/livebook/live_markdown/markdown_helpers.ex
+++ b/lib/livebook/live_markdown/markdown_helpers.ex
@@ -99,6 +99,12 @@ defmodule Livebook.LiveMarkdown.MarkdownHelpers do
     |> build_md(ast)
   end
 
+  defp build_md(iodata, [{"br", _, [], %{}} | ast]) do
+    render_line_break()
+    |> append_inline(iodata)
+    |> build_md(ast)
+  end
+
   defp build_md(iodata, [{"p", _, content, %{}} | ast]) do
     render_paragraph(content)
     |> append_block(iodata)
@@ -224,6 +230,8 @@ defmodule Livebook.LiveMarkdown.MarkdownHelpers do
       "thick" -> "***"
     end
   end
+
+  defp render_line_break(), do: "\\\n"
 
   defp render_paragraph(content), do: markdown_from_ast(content)
 

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -98,6 +98,9 @@ defmodule Livebook.LiveMarkdown.ImportTest do
 
     ## Section 1
 
+    Line 1.\s\s
+    Line 2.
+
     |State|Abbrev|Capital|
     | --: | :-: | --- |
     | Texas | TX | Austin |
@@ -117,6 +120,9 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                      type: :markdown,
                      metadata: %{},
                      source: """
+                     Line 1.\\
+                     Line 2.
+
                      | State | Abbrev | Capital |
                      | ----: | :----: | ------- |
                      | Texas | TX     | Austin  |


### PR DESCRIPTION
Fixes the crash reported in #218 (closes #218). There's still the more concerning problem with how equations are interpreted as markdown, but gonna create a separate issue for that.

The problem here was that we didn't account for the `<br>` tag, which may be generated in markdown by appending `\` or double space at the end of line.