### PR TITLE
Explicitly dispose Monaco editor instance when cell is deleted

### DIFF
--- a/assets/js/cell/index.js
+++ b/assets/js/cell/index.js
@@ -83,6 +83,10 @@ const Cell = {
 
   destroyed() {
     globalPubSub.unsubscribe("session", this.handleSessionEvent);
+
+    if (this.state.liveEditor) {
+      this.state.liveEditor.destroy();
+    }
   },
 
   updated() {

--- a/assets/js/cell/live_editor.js
+++ b/assets/js/cell/live_editor.js
@@ -71,6 +71,20 @@ class LiveEditor {
       .pushEditOperations([], [{ forceMoveMarkers: true, range, text }]);
   }
 
+  /**
+   * Performs necessary cleanup actions.
+   */
+  destroy() {
+    // Explicitly destroy the editor instance and its text model.
+    this.editor.dispose();
+
+    const model = this.editor.getModel();
+
+    if (model) {
+      model.dispose();
+    }
+  }
+
   __mountEditor() {
     this.editor = monaco.editor.create(this.container, {
       language: this.type,


### PR DESCRIPTION
Closes #212.

I didn't find an explicit documentation suggesting that we have to dispose of the editor when the element is removed, but apparently that's what they do on the Monaco website and also what `react-monaco-editor` does. Turns out this fixes the referenced issue :man_shrugging: 