### PR TITLE
Feature cell link

### DIFF
--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -59,6 +59,14 @@ const Session = {
       handleCellIndicatorsClick(this, event);
     });
 
+    window.addEventListener(
+      "phx:page-loading-stop",
+      () => {
+        focusCellFromUrl(this);
+      },
+      { once: true }
+    );
+
     // DOM setup
 
     updateSectionListHighlight();
@@ -279,6 +287,20 @@ function handleCellIndicatorsClick(hook, event) {
   if (button) {
     const cellId = button.getAttribute("data-target");
     setFocusedCell(hook, cellId);
+  }
+}
+
+/**
+ * Focuses cell based on the given URL.
+ */
+function focusCellFromUrl(hook) {
+  const hash = window.location.hash;
+
+  if (hash.startsWith("#cell-")) {
+    const cellId = hash.replace(/^#cell-/, "");
+    if (getCellById(cellId)) {
+      setFocusedCell(hook, cellId);
+    }
   }
 }
 

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -177,7 +177,6 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     """
   end
 
-
   # The whole page has to load and then hooks are mounded.
   # There may be a tiny delay before the markdown is rendered
   # or editors are mounted, so show neat placeholders immediately.

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -17,7 +17,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
   def render_cell_content(%{cell_view: %{type: :markdown}} = assigns) do
     ~L"""
-    <div class="flex items-center justify-end">
+    <div class="mb-1 flex items-center justify-end">
       <div class="relative z-10 flex items-center justify-end space-x-2" data-element="actions">
         <%= render_cell_anchor_link(@cell_view) %>
         <span class="tooltip top" aria-label="Edit content" data-element="enable-insert-mode-button">
@@ -75,7 +75,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
   def render_cell_content(%{cell_view: %{type: :elixir}} = assigns) do
     ~L"""
-    <div class="mb-1 flex justify-between">
+    <div class="mb-1 flex items-center justify-between">
       <div class="relative z-10 flex items-center justify-end space-x-2" data-element="actions" data-primary>
         <%= if @cell_view.evaluation_status == :ready do %>
           <button class="text-gray-600 hover:text-gray-800 focus:text-gray-800 flex space-x-1 items-center"

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -17,8 +17,9 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
   def render_cell_content(%{cell_view: %{type: :markdown}} = assigns) do
     ~L"""
-    <div class="mb-1 flex items-center justify-end">
+    <div class="flex items-center justify-end">
       <div class="relative z-10 flex items-center justify-end space-x-2" data-element="actions">
+        <%= render_cell_anchor_link(@cell_view) %>
         <span class="tooltip top" aria-label="Edit content" data-element="enable-insert-mode-button">
           <button class="icon-button">
             <%= remix_icon("pencil-line", class: "text-xl") %>
@@ -74,7 +75,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
   def render_cell_content(%{cell_view: %{type: :elixir}} = assigns) do
     ~L"""
-    <div class="mb-1 flex items-center justify-between">
+    <div class="mb-1 flex justify-between">
       <div class="relative z-10 flex items-center justify-end space-x-2" data-element="actions" data-primary>
         <%= if @cell_view.evaluation_status == :ready do %>
           <button class="text-gray-600 hover:text-gray-800 focus:text-gray-800 flex space-x-1 items-center"
@@ -97,6 +98,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
         <% end %>
       </div>
       <div class="relative z-10 flex items-center justify-end space-x-2" data-element="actions">
+        <%= render_cell_anchor_link(@cell_view) %>
         <span class="tooltip top" aria-label="Cell settings">
           <%= live_patch to: Routes.session_path(@socket, :cell_settings, @session_id, @cell_view.id), class: "icon-button" do %>
             <%= remix_icon("list-settings-line", class: "text-xl") %>
@@ -162,6 +164,19 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     </div>
     """
   end
+
+  defp render_cell_anchor_link(cell_view) do
+    assigns = %{cell_view: cell_view}
+
+    ~L"""
+    <span class="tooltip top" aria-label="Link">
+      <a href="#cell-<%= @cell_view.id %>" class="icon-button">
+        <%= remix_icon("link", class: "text-xl") %>
+      </a>
+    </span>
+    """
+  end
+
 
   # The whole page has to load and then hooks are mounded.
   # There may be a tiny delay before the markdown is rendered


### PR DESCRIPTION
Add anchor links to sections and cells.
It adds the tooltip icon in the cell actions when content type is markdown or elixir.

![image](https://user-images.githubusercontent.com/11801/115914170-e5e23900-a471-11eb-958c-5dc11c3f247d.png)
