### PR TITLE
Setup user profiles

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -74,6 +74,10 @@
   @apply w-full px-3 py-2 bg-gray-50 text-sm border border-gray-200 rounded-lg placeholder-gray-400 text-gray-600;
 }
 
+.input-label {
+  @apply mb-0.5 text-sm text-gray-800 font-medium;
+}
+
 .switch-button {
   @apply relative inline-block w-14 h-7 mr-2 select-none transition;
 }

--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -73,13 +73,28 @@ solely client-side operations.
   @apply bg-blue-300;
 }
 
-[data-element="session"]:not([data-js-sections-panel-expanded])
-  [data-element="sections-panel"] {
+[data-element="session"]:not([data-js-side-panel-content])
+  [data-element="side-panel"] {
   @apply hidden;
 }
 
-[data-element="session"][data-js-sections-panel-expanded]
-  [data-element="sections-panel-toggle"] {
+[data-element="session"]:not([data-js-side-panel-content="sections-list"])
+  [data-element="sections-list"] {
+  @apply hidden;
+}
+
+[data-element="session"]:not([data-js-side-panel-content="users-list"])
+  [data-element="users-list"] {
+  @apply hidden;
+}
+
+[data-element="session"][data-js-side-panel-content="sections-list"]
+  [data-element="sections-list-toggle"] {
+  @apply text-gray-50 bg-gray-700;
+}
+
+[data-element="session"][data-js-side-panel-content="users-list"]
+  [data-element="users-list-toggle"] {
   @apply text-gray-50 bg-gray-700;
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -18,6 +18,7 @@ import FocusOnUpdate from "./focus_on_update";
 import ScrollOnUpdate from "./scroll_on_update";
 import VirtualizedLines from "./virtualized_lines";
 import Menu from "./menu";
+import UserForm from "./user_form";
 import morphdomCallbacks from "./morphdom_callbacks";
 
 const hooks = {
@@ -28,6 +29,7 @@ const hooks = {
   ScrollOnUpdate,
   VirtualizedLines,
   Menu,
+  UserForm,
 };
 
 const csrfToken = document

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -20,6 +20,7 @@ import VirtualizedLines from "./virtualized_lines";
 import Menu from "./menu";
 import UserForm from "./user_form";
 import morphdomCallbacks from "./morphdom_callbacks";
+import { loadUserData } from "./lib/user";
 
 const hooks = {
   ContentEditable,
@@ -37,7 +38,13 @@ const csrfToken = document
   .getAttribute("content");
 
 const liveSocket = new LiveSocket("/live", Socket, {
-  params: { _csrf_token: csrfToken },
+  params: (liveViewName) => {
+    return {
+      _csrf_token: csrfToken,
+      // Pass the most recent user data to the LiveView in `connect_params`
+      user_data: loadUserData(),
+    };
+  },
   hooks: hooks,
   dom: morphdomCallbacks,
 });

--- a/assets/js/lib/user.js
+++ b/assets/js/lib/user.js
@@ -1,0 +1,43 @@
+import { decodeBase64, encodeBase64 } from "./utils";
+
+const USER_DATA_COOKIE = "user_data";
+
+/**
+ * Stores user data in the `"user_data"` cookie.
+ */
+export function storeUserData(userData) {
+  const json = JSON.stringify(userData);
+  const encoded = encodeBase64(json);
+  setCookie(USER_DATA_COOKIE, encoded, 157_680_000); // 5 years
+}
+
+/**
+ * Loads user data from the `"user_data"` cookie.
+ */
+export function loadUserData() {
+  const encoded = getCookieValue(USER_DATA_COOKIE);
+  if (encoded) {
+    const json = decodeBase64(encoded);
+    return JSON.parse(json);
+  } else {
+    return null;
+  }
+}
+
+function getCookieValue(key) {
+  const cookie = document.cookie
+    .split("; ")
+    .find((cookie) => cookie.startsWith(`${key}=`));
+
+  if (cookie) {
+    const value = cookie.replace(`${key}=`, "");
+    return value;
+  } else {
+    return null;
+  }
+}
+
+function setCookie(key, value, maxAge) {
+  const cookie = `${key}=${value};max-age=${maxAge};path=/`;
+  document.cookie = cookie;
+}

--- a/assets/js/lib/utils.js
+++ b/assets/js/lib/utils.js
@@ -49,3 +49,17 @@ export function smoothlyScrollToElement(element) {
     element.scrollIntoView({ behavior: "smooth", block: "start" });
   }
 }
+
+/**
+ * Transforms a UTF8 string into base64 encoding.
+ */
+export function encodeBase64(string) {
+  return btoa(unescape(encodeURIComponent(string)));
+}
+
+/**
+ * Transforms base64 encoding into UTF8 string.
+ */
+export function decodeBase64(binary) {
+  return decodeURIComponent(escape(atob(binary)));
+}

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -47,8 +47,12 @@ const Session = {
       handleSectionListClick(this, event);
     });
 
-    getSectionsPanelToggle().addEventListener("click", (event) => {
-      toggleSectionsPanel(this);
+    getSectionsListToggle().addEventListener("click", (event) => {
+      toggleSectionsList(this);
+    });
+
+    getUsersListToggle().addEventListener("click", (event) => {
+      toggleUsersList(this);
     });
 
     getNotebook().addEventListener("scroll", (event) => {
@@ -179,7 +183,9 @@ function handleDocumentKeyDown(hook, event) {
     } else if (keyBuffer.tryMatch(["e", "j"])) {
       queueChildCellsEvaluation(hook);
     } else if (keyBuffer.tryMatch(["s", "s"])) {
-      toggleSectionsPanel(hook);
+      toggleSectionsList(hook);
+    } else if (keyBuffer.tryMatch(["s", "u"])) {
+      toggleUsersList(hook);
     } else if (keyBuffer.tryMatch(["s", "r"])) {
       showNotebookRuntimeSettings(hook);
     } else if (keyBuffer.tryMatch(["e", "x"])) {
@@ -336,8 +342,20 @@ function updateSectionListHighlight() {
 
 // User action handlers (mostly keybindings)
 
-function toggleSectionsPanel(hook) {
-  hook.el.toggleAttribute("data-js-sections-panel-expanded");
+function toggleSectionsList(hook) {
+  if (hook.el.getAttribute("data-js-side-panel-content") === "sections-list") {
+    hook.el.removeAttribute("data-js-side-panel-content");
+  } else {
+    hook.el.setAttribute("data-js-side-panel-content", "sections-list");
+  }
+}
+
+function toggleUsersList(hook) {
+  if (hook.el.getAttribute("data-js-side-panel-content") === "users-list") {
+    hook.el.removeAttribute("data-js-side-panel-content");
+  } else {
+    hook.el.setAttribute("data-js-side-panel-content", "users-list");
+  }
 }
 
 function showNotebookRuntimeSettings(hook) {
@@ -639,8 +657,12 @@ function getNotebook() {
   return document.querySelector(`[data-element="notebook"]`);
 }
 
-function getSectionsPanelToggle() {
-  return document.querySelector(`[data-element="sections-panel-toggle"]`);
+function getSectionsListToggle() {
+  return document.querySelector(`[data-element="sections-list-toggle"]`);
+}
+
+function getUsersListToggle() {
+  return document.querySelector(`[data-element="users-list-toggle"]`);
 }
 
 function cancelEvent(event) {

--- a/assets/js/user_form/index.js
+++ b/assets/js/user_form/index.js
@@ -1,0 +1,29 @@
+/**
+ * A hook for the user profile form.
+ *
+ * On submit this hook saves the new data into cookie.
+ * This cookie serves as a backup and can be used to restore
+ * user data if the server is restarted.
+ */
+const UserForm = {
+  mounted() {
+    this.el.addEventListener("submit", (event) => {
+      // TODO: We shouldn't really care if null or not, and validate on the server anyway
+      const name = this.el.data_name.value || null;
+      const color = this.el.data_color.value;
+      storeUserData({ name, color });
+    });
+  },
+};
+
+function storeUserData(userData) {
+  const value = JSON.stringify(userData);
+  setCookie("user_data", value, 157680000); // 5 years
+}
+
+function setCookie(key, value, maxAge) {
+  const cookie = `${key}=${value};max-age=${maxAge};path=/`;
+  document.cookie = cookie;
+}
+
+export default UserForm;

--- a/assets/js/user_form/index.js
+++ b/assets/js/user_form/index.js
@@ -1,3 +1,5 @@
+import { storeUserData } from "../lib/user";
+
 /**
  * A hook for the user profile form.
  *
@@ -14,15 +16,5 @@ const UserForm = {
     });
   },
 };
-
-function storeUserData(userData) {
-  const value = JSON.stringify(userData);
-  setCookie("user_data", value, 157680000); // 5 years
-}
-
-function setCookie(key, value, maxAge) {
-  const cookie = `${key}=${value};max-age=${maxAge};path=/`;
-  document.cookie = cookie;
-}
 
 export default UserForm;

--- a/assets/js/user_form/index.js
+++ b/assets/js/user_form/index.js
@@ -8,8 +8,7 @@
 const UserForm = {
   mounted() {
     this.el.addEventListener("submit", (event) => {
-      // TODO: We shouldn't really care if null or not, and validate on the server anyway
-      const name = this.el.data_name.value || null;
+      const name = this.el.data_name.value;
       const color = this.el.data_color.value;
       storeUserData({ name, color });
     });

--- a/assets/js/user_form/index.js
+++ b/assets/js/user_form/index.js
@@ -11,8 +11,8 @@ const UserForm = {
   mounted() {
     this.el.addEventListener("submit", (event) => {
       const name = this.el.data_name.value;
-      const color = this.el.data_color.value;
-      storeUserData({ name, color });
+      const hex_color = this.el.data_hex_color.value;
+      storeUserData({ name, hex_color });
     });
   },
 };

--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -9,8 +9,6 @@ defmodule Livebook.Application do
     ensure_distribution!()
     set_cookie()
 
-    Livebook.Users.initialize_store()
-
     children = [
       # Start the Telemetry supervisor
       LivebookWeb.Telemetry,

--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -9,6 +9,8 @@ defmodule Livebook.Application do
     ensure_distribution!()
     set_cookie()
 
+    Livebook.Users.initialize_store()
+
     children = [
       # Start the Telemetry supervisor
       LivebookWeb.Telemetry,

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -16,6 +16,7 @@ defmodule Livebook.Session do
 
   alias Livebook.Session.{Data, FileGuard}
   alias Livebook.{Utils, Notebook, Delta, Runtime, LiveMarkdown}
+  alias Livebook.Users.User
   alias Livebook.Notebook.{Cell, Section}
 
   @type state :: %{
@@ -82,9 +83,9 @@ defmodule Livebook.Session do
   keep in sync with the server by subscribing to the `sessions:id` topic
   and receiving operations to apply.
   """
-  @spec register_client(id(), Data.client()) :: Data.t()
-  def register_client(session_id, client) do
-    GenServer.call(name(session_id), {:register_client, client})
+  @spec register_client(id(), pid(), User.t()) :: Data.t()
+  def register_client(session_id, client_pid, user) do
+    GenServer.call(name(session_id), {:register_client, client_pid, user})
   end
 
   @doc """
@@ -317,11 +318,10 @@ defmodule Livebook.Session do
   end
 
   @impl true
-  def handle_call({:register_client, client}, _from, state) do
-    {_user_id, pid} = client
-    Process.monitor(pid)
+  def handle_call({:register_client, client_pid, user}, _from, state) do
+    Process.monitor(client_pid)
 
-    state = handle_operation(state, {:client_join, client})
+    state = handle_operation(state, {:client_join, client_pid, user})
 
     {:reply, state.data, state}
   end
@@ -475,11 +475,10 @@ defmodule Livebook.Session do
 
   def handle_info({:DOWN, _, :process, pid, _}, state) do
     state =
-      state.data.clients
-      |> Enum.find(&match?({_user_id, ^pid}, &1))
-      |> case do
-        nil -> state
-        client -> handle_operation(state, {:client_leave, client})
+      if Map.has_key?(state.data.clients_map, pid) do
+        handle_operation(state, {:client_leave, pid})
+      else
+        state
       end
 
     {:noreply, state}
@@ -505,6 +504,11 @@ defmodule Livebook.Session do
   def handle_info(:autosave, state) do
     Process.send_after(self(), :autosave, @autosave_interval)
     {:noreply, maybe_save_notebook(state)}
+  end
+
+  def handle_info({:user_change, user}, state) do
+    operation = {:update_user, self(), user}
+    {:noreply, handle_operation(state, operation)}
   end
 
   def handle_info(_message, state), do: {:noreply, state}
@@ -603,6 +607,24 @@ defmodule Livebook.Session do
       copy_images(state, prev_images_dir)
     else
       move_images(state, prev_images_dir)
+    end
+
+    state
+  end
+
+  defp after_operation(state, prev_state, {:client_join, _client_pid, user}) do
+    unless Map.has_key?(prev_state.data.users_map, user.id) do
+      Phoenix.PubSub.subscribe(Livebook.PubSub, "users:#{user.id}")
+    end
+
+    state
+  end
+
+  defp after_operation(state, prev_state, {:client_leave, client_pid}) do
+    user_id = prev_state.data.clients_map[client_pid]
+
+    unless Map.has_key?(state.data.users_map, user_id) do
+      Phoenix.PubSub.unsubscribe(Livebook.PubSub, "users:#{user_id}")
     end
 
     state

--- a/lib/livebook/users.ex
+++ b/lib/livebook/users.ex
@@ -1,34 +1,69 @@
 defmodule Livebook.Users do
   @moduledoc false
 
+  # Module responsible for user storage
+  # and broadcasting change notifications.
+  #
+  # Users are stored in an ETS table.
+
+  alias Livebook.Users.User
+
   @users_table :livebook_users
 
+  @doc """
+  Creates the ETS users table.
+  """
+  @spec initialize_store() :: :ok
   def initialize_store() do
     :ets.new(@users_table, [:set, :public, :named_table])
     :ok
   end
 
-  def exists?(user_id) do
-    :ets.member(@users_table, user_id)
-  end
+  @doc """
+  Saves the given user in the store.
 
+  If a user with the given `id` is already in the store
+  it gets replaced, so this function either inserts
+  or updates the user.
+
+  Broadcasts `{:user_saved, user}` message under the `"user:{id}"` topic.
+  """
+  @spec save(User.t()) :: :ok
   def save(user) do
     :ets.insert(@users_table, {user.id, user})
     broadcast_user_message(user.id, {:user_saved, user})
     :ok
   end
 
-  def list_by_ids(user_ids) do
-    match_spec = for user_id <- user_ids, do: {{user_id, :_}, [], [:"$_"]}
-    results = :ets.select(@users_table, match_spec)
-    Enum.map(results, &elem(&1, 1))
+  @doc """
+  Checks if a user with the given id already exists.
+  """
+  @spec exists?(User.id()) :: boolean()
+  def exists?(user_id) do
+    :ets.member(@users_table, user_id)
   end
 
+  @doc """
+  Find user with the given id in the store.
+
+  Raises and error if no user is found.
+  """
+  @spec fetch!(User.id()) :: User.t()
   def fetch!(user_id) do
     case :ets.lookup(@users_table, user_id) do
       [{_id, user}] -> user
       _ -> raise "expected to find user with id #{user_id}, but found none"
     end
+  end
+
+  @doc """
+  Retrieves users from the store for the given list of ids.
+  """
+  @spec list_by_ids(list(User.id())) :: list(User.t())
+  def list_by_ids(user_ids) do
+    match_spec = for user_id <- user_ids, do: {{user_id, :_}, [], [:"$_"]}
+    results = :ets.select(@users_table, match_spec)
+    Enum.map(results, &elem(&1, 1))
   end
 
   defp broadcast_user_message(user_id, message) do

--- a/lib/livebook/users.ex
+++ b/lib/livebook/users.ex
@@ -23,8 +23,15 @@ defmodule Livebook.Users do
   end
 
   def list_by_ids(user_ids) do
-    match_spec = (for user_id <- user_ids, do: {{user_id, :_}, [], [:"$_"]})
+    match_spec = for user_id <- user_ids, do: {{user_id, :_}, [], [:"$_"]}
     results = :ets.select(@users_table, match_spec)
     Enum.map(results, &elem(&1, 1))
+  end
+
+  def fetch!(user_id) do
+    case :ets.lookup(@users_table, user_id) do
+      [{_id, user}] -> user
+      _ -> raise "expected to find user with id #{user_id}, but found none"
+    end
   end
 end

--- a/lib/livebook/users.ex
+++ b/lib/livebook/users.ex
@@ -34,4 +34,14 @@ defmodule Livebook.Users do
       _ -> raise "expected to find user with id #{user_id}, but found none"
     end
   end
+
+  def update(user) do
+    :ets.insert(@users_table, {user.id, user})
+    broadcast_message({:user_updated, user})
+    {:ok, user}
+  end
+
+  defp broadcast_message(message) do
+    Phoenix.PubSub.broadcast(Livebook.PubSub, "users", message)
+  end
 end

--- a/lib/livebook/users.ex
+++ b/lib/livebook/users.ex
@@ -16,7 +16,7 @@ defmodule Livebook.Users do
 
   def save(user) do
     :ets.insert(@users_table, {user.id, user})
-    broadcast_message({:user_saved, user})
+    broadcast_user_message(user.id, {:user_saved, user})
     :ok
   end
 
@@ -33,7 +33,7 @@ defmodule Livebook.Users do
     end
   end
 
-  defp broadcast_message(message) do
-    Phoenix.PubSub.broadcast(Livebook.PubSub, "users", message)
+  defp broadcast_user_message(user_id, message) do
+    Phoenix.PubSub.broadcast(Livebook.PubSub, "users:#{user_id}", message)
   end
 end

--- a/lib/livebook/users.ex
+++ b/lib/livebook/users.ex
@@ -1,8 +1,6 @@
 defmodule Livebook.Users do
   @moduledoc false
 
-  # TODO: docs
-
   @users_table :livebook_users
 
   def initialize_store() do

--- a/lib/livebook/users.ex
+++ b/lib/livebook/users.ex
@@ -1,8 +1,6 @@
 defmodule Livebook.Users do
   @moduledoc false
 
-  alias Livebook.Users.User
-
   # TODO: docs
 
   @users_table :livebook_users
@@ -16,10 +14,10 @@ defmodule Livebook.Users do
     :ets.member(@users_table, user_id)
   end
 
-  def create(attrs \\ %{}) do
-    user = User.new(attrs)
+  def save(user) do
     :ets.insert(@users_table, {user.id, user})
-    {:ok, user}
+    broadcast_message({:user_saved, user})
+    :ok
   end
 
   def list_by_ids(user_ids) do
@@ -33,12 +31,6 @@ defmodule Livebook.Users do
       [{_id, user}] -> user
       _ -> raise "expected to find user with id #{user_id}, but found none"
     end
-  end
-
-  def update(user) do
-    :ets.insert(@users_table, {user.id, user})
-    broadcast_message({:user_updated, user})
-    {:ok, user}
   end
 
   defp broadcast_message(message) do

--- a/lib/livebook/users.ex
+++ b/lib/livebook/users.ex
@@ -1,69 +1,17 @@
 defmodule Livebook.Users do
   @moduledoc false
 
-  # Module responsible for user storage
-  # and broadcasting change notifications.
-  #
-  # Users are stored in an ETS table.
-
   alias Livebook.Users.User
 
-  @users_table :livebook_users
-
   @doc """
-  Creates the ETS users table.
+  Notifies interested processes about user data change.
+
+  Broadcasts `{:user_change, user}` message under the `"user:{id}"` topic.
   """
-  @spec initialize_store() :: :ok
-  def initialize_store() do
-    :ets.new(@users_table, [:set, :public, :named_table])
+  @spec broadcast_change(User.t()) :: :ok
+  def broadcast_change(user) do
+    broadcast_user_message(user.id, {:user_change, user})
     :ok
-  end
-
-  @doc """
-  Saves the given user in the store.
-
-  If a user with the given `id` is already in the store
-  it gets replaced, so this function either inserts
-  or updates the user.
-
-  Broadcasts `{:user_saved, user}` message under the `"user:{id}"` topic.
-  """
-  @spec save(User.t()) :: :ok
-  def save(user) do
-    :ets.insert(@users_table, {user.id, user})
-    broadcast_user_message(user.id, {:user_saved, user})
-    :ok
-  end
-
-  @doc """
-  Checks if a user with the given id already exists.
-  """
-  @spec exists?(User.id()) :: boolean()
-  def exists?(user_id) do
-    :ets.member(@users_table, user_id)
-  end
-
-  @doc """
-  Find user with the given id in the store.
-
-  Raises and error if no user is found.
-  """
-  @spec fetch!(User.id()) :: User.t()
-  def fetch!(user_id) do
-    case :ets.lookup(@users_table, user_id) do
-      [{_id, user}] -> user
-      _ -> raise "expected to find user with id #{user_id}, but found none"
-    end
-  end
-
-  @doc """
-  Retrieves users from the store for the given list of ids.
-  """
-  @spec list_by_ids(list(User.id())) :: list(User.t())
-  def list_by_ids(user_ids) do
-    match_spec = for user_id <- user_ids, do: {{user_id, :_}, [], [:"$_"]}
-    results = :ets.select(@users_table, match_spec)
-    Enum.map(results, &elem(&1, 1))
   end
 
   defp broadcast_user_message(user_id, message) do

--- a/lib/livebook/users.ex
+++ b/lib/livebook/users.ex
@@ -1,0 +1,24 @@
+defmodule Livebook.Users do
+  @moduledoc false
+
+  alias Livebook.Users.User
+
+  # TODO: docs
+
+  @users_table :livebook_users
+
+  def initialize_store() do
+    :ets.new(@users_table, [:set, :public, :named_table])
+    :ok
+  end
+
+  def exists?(user_id) do
+    :ets.member(@users_table, user_id)
+  end
+
+  def create(attrs \\ %{}) do
+    user = User.new(attrs)
+    :ets.insert(@users_table, {user.id, user})
+    {:ok, user}
+  end
+end

--- a/lib/livebook/users.ex
+++ b/lib/livebook/users.ex
@@ -21,4 +21,10 @@ defmodule Livebook.Users do
     :ets.insert(@users_table, {user.id, user})
     {:ok, user}
   end
+
+  def list_by_ids(user_ids) do
+    match_spec = (for user_id <- user_ids, do: {{user_id, :_}, [], [:"$_"]})
+    results = :ets.select(@users_table, match_spec)
+    Enum.map(results, &elem(&1, 1))
+  end
 end

--- a/lib/livebook/users/user.ex
+++ b/lib/livebook/users/user.ex
@@ -1,0 +1,20 @@
+defmodule Livebook.Users.User do
+  defstruct [:id, :name, :color]
+
+  def new(attrs \\ %{}) do
+    %__MODULE__{
+      id: Livebook.Utils.random_id(),
+      name: Map.get(attrs, :name, nil),
+      color: Map.get_lazy(attrs, :color, &random_color/0)
+    }
+  end
+
+  def random_color() do
+    # TODO: use HSV and vary H only? or predefined list of neat colors?
+    #   - we want the color to fit white text, so just gather a reasonable list of colors
+    # TODO: also color picker
+    #   - native picker would trigger change too often, we need either a lib
+    #     or something else
+    Enum.random(["#F87171", "#FBBF24", "#6EE7B7", "#60A5FA", "#818CF8", "#A78BFA", "#F472B6"])
+  end
+end

--- a/lib/livebook/users/user.ex
+++ b/lib/livebook/users/user.ex
@@ -1,9 +1,13 @@
 defmodule Livebook.Users.User do
   defstruct [:id, :name, :color]
 
+  alias Livebook.Utils
+
+  @type id :: Utils.id()
+
   def new(attrs \\ %{}) do
     %__MODULE__{
-      id: Livebook.Utils.random_id(),
+      id: Utils.random_id(),
       name: Map.get(attrs, :name, nil),
       color: Map.get_lazy(attrs, :color, &random_color/0)
     }

--- a/lib/livebook/users/user.ex
+++ b/lib/livebook/users/user.ex
@@ -1,10 +1,31 @@
 defmodule Livebook.Users.User do
+  @moduledoc false
+
+  # Represents a Livebook user.
+  #
+  # Livebook users are not regular web app accounts,
+  # but rather ephemeral data about the clients
+  # using the app. Every person using Livebook
+  # can provide data like name and cursor color
+  # to improve visibility during collaboration.
+
   defstruct [:id, :name, :color]
 
   alias Livebook.Utils
 
-  @type id :: Utils.id()
+  @type t :: %__MODULE__{
+          id: id(),
+          name: String.t() | nil,
+          color: color()
+        }
 
+  @type id :: Utils.id()
+  @type color :: String.t()
+
+  @doc """
+  Generates a new user.
+  """
+  @spec new() :: t()
   def new() do
     %__MODULE__{
       id: Utils.random_id(),
@@ -13,6 +34,14 @@ defmodule Livebook.Users.User do
     }
   end
 
+  @doc """
+  Validates `attrs` and returns an updated user.
+
+  In case of validation errors `{:error, errors, user}` tuple
+  is returned, where `user` is partially updated by using
+  only the valid attributes.
+  """
+  @spec change(t(), %{binary() => any()}) :: {:ok, t()} | {:error, list(String.t()), t()}
   def change(user, attrs \\ %{}) do
     {user, []}
     |> change_name(attrs)
@@ -45,6 +74,13 @@ defmodule Livebook.Users.User do
 
   defp color_valid?(color), do: color =~ ~r/^#[0-9a-fA-F]{6}$/
 
+  @doc """
+  Returns a random hex color for a user.
+
+  ## Options
+
+    * `:except` - a list of colors to omit
+  """
   def random_color(opts \\ []) do
     colors = [
       # red

--- a/lib/livebook/users/user.ex
+++ b/lib/livebook/users/user.ex
@@ -9,18 +9,18 @@ defmodule Livebook.Users.User do
   # can provide data like name and cursor color
   # to improve visibility during collaboration.
 
-  defstruct [:id, :name, :color]
+  defstruct [:id, :name, :hex_color]
 
   alias Livebook.Utils
 
   @type t :: %__MODULE__{
           id: id(),
           name: String.t() | nil,
-          color: color()
+          hex_color: hex_color()
         }
 
   @type id :: Utils.id()
-  @type color :: String.t()
+  @type hex_color :: String.t()
 
   @doc """
   Generates a new user.
@@ -30,7 +30,7 @@ defmodule Livebook.Users.User do
     %__MODULE__{
       id: Utils.random_id(),
       name: nil,
-      color: random_color()
+      hex_color: random_hex_color()
     }
   end
 
@@ -45,7 +45,7 @@ defmodule Livebook.Users.User do
   def change(user, attrs \\ %{}) do
     {user, []}
     |> change_name(attrs)
-    |> change_color(attrs)
+    |> change_hex_color(attrs)
     |> case do
       {user, []} -> {:ok, user}
       {user, errors} -> {:error, errors, user}
@@ -62,17 +62,17 @@ defmodule Livebook.Users.User do
 
   defp change_name({user, errors}, _attrs), do: {user, errors}
 
-  defp change_color({user, errors}, %{"color" => color}) do
-    if color_valid?(color) do
-      {%{user | color: color}, errors}
+  defp change_hex_color({user, errors}, %{"hex_color" => hex_color}) do
+    if hex_color_valid?(hex_color) do
+      {%{user | hex_color: hex_color}, errors}
     else
-      {user, [{:color, "not a valid color"} | errors]}
+      {user, [{:hex_color, "not a valid color"} | errors]}
     end
   end
 
-  defp change_color({user, errors}, _attrs), do: {user, errors}
+  defp change_hex_color({user, errors}, _attrs), do: {user, errors}
 
-  defp color_valid?(color), do: color =~ ~r/^#[0-9a-fA-F]{6}$/
+  defp hex_color_valid?(hex_color), do: hex_color =~ ~r/^#[0-9a-fA-F]{6}$/
 
   @doc """
   Returns a random hex color for a user.
@@ -81,7 +81,7 @@ defmodule Livebook.Users.User do
 
     * `:except` - a list of colors to omit
   """
-  def random_color(opts \\ []) do
+  def random_hex_color(opts \\ []) do
     colors = [
       # red
       "#F87171",

--- a/lib/livebook/users/user.ex
+++ b/lib/livebook/users/user.ex
@@ -45,12 +45,29 @@ defmodule Livebook.Users.User do
 
   defp color_valid?(color), do: color =~ ~r/^#[0-9a-fA-F]{6}$/
 
-  def random_color() do
-    # TODO: use HSV and vary H only? or predefined list of neat colors?
-    #   - we want the color to fit white text, so just gather a reasonable list of colors
-    # TODO: also color picker
-    #   - native picker would trigger change too often, we need either a lib
-    #     or something else
-    Enum.random(["#F87171", "#FBBF24", "#6EE7B7", "#60A5FA", "#818CF8", "#A78BFA", "#F472B6"])
+  def random_color(opts \\ []) do
+    colors = [
+      # red
+      "#F87171",
+      # yellow
+      "#FBBF24",
+      # green
+      "#6EE7B7",
+      # blue
+      "#60A5FA",
+      # purple
+      "#A78BFA",
+      # pink
+      "#F472B6",
+      # salmon
+      "#FA8072",
+      # mat green
+      "#9ED9CC"
+    ]
+
+    except = opts[:except] || []
+    colors = colors -- except
+
+    Enum.random(colors)
   end
 end

--- a/lib/livebook/users/user.ex
+++ b/lib/livebook/users/user.ex
@@ -13,6 +13,8 @@ defmodule Livebook.Users.User do
     }
   end
 
+  def color_valid?(color), do: color =~ ~r/^#[0-9a-fA-F]{6}$/
+
   def random_color() do
     # TODO: use HSV and vary H only? or predefined list of neat colors?
     #   - we want the color to fit white text, so just gather a reasonable list of colors

--- a/lib/livebook_web/live/home_live.ex
+++ b/lib/livebook_web/live/home_live.ex
@@ -1,9 +1,9 @@
 defmodule LivebookWeb.HomeLive do
   use LivebookWeb, :live_view
 
-  import LivebookWeb.LiveHelpers
+  import LivebookWeb.UserHelpers
 
-  alias Livebook.{SessionSupervisor, Session, LiveMarkdown, Notebook, Users}
+  alias Livebook.{SessionSupervisor, Session, LiveMarkdown, Notebook}
 
   @impl true
   def mount(_params, %{"current_user_id" => current_user_id}, socket) do
@@ -12,7 +12,7 @@ defmodule LivebookWeb.HomeLive do
       Phoenix.PubSub.subscribe(Livebook.PubSub, "users:#{current_user_id}")
     end
 
-    current_user = Users.fetch!(current_user_id)
+    current_user = build_current_user(current_user_id, socket)
     session_summaries = sort_session_summaries(SessionSupervisor.get_session_summaries())
 
     {:ok,
@@ -27,7 +27,7 @@ defmodule LivebookWeb.HomeLive do
   def render(assigns) do
     ~L"""
     <div class="flex flex-grow h-full">
-      <div class="flex flex-col items-center space-y-5 px-3 py-7 bg-gray-900">
+      <div class="w-16 flex flex-col items-center space-y-5 px-3 py-7 bg-gray-900">
         <div class="flex-grow"></div>
         <span class="tooltip right distant" aria-label="User profile">
           <%= live_patch to: Routes.home_path(@socket, :user),
@@ -208,7 +208,7 @@ defmodule LivebookWeb.HomeLive do
   end
 
   def handle_info(
-        {:user_saved, %{id: id} = user},
+        {:user_change, %{id: id} = user},
         %{assigns: %{current_user: %{id: id}}} = socket
       ) do
     {:noreply, assign(socket, :current_user, user)}

--- a/lib/livebook_web/live/home_live.ex
+++ b/lib/livebook_web/live/home_live.ex
@@ -1,23 +1,41 @@
 defmodule LivebookWeb.HomeLive do
   use LivebookWeb, :live_view
 
-  alias Livebook.{SessionSupervisor, Session, LiveMarkdown, Notebook}
+  import LivebookWeb.LiveHelpers
+
+  alias Livebook.{SessionSupervisor, Session, LiveMarkdown, Notebook, Users}
 
   @impl true
-  def mount(_params, _session, socket) do
+  def mount(_params, %{"current_user_id" => current_user_id}, socket) do
     if connected?(socket) do
       Phoenix.PubSub.subscribe(Livebook.PubSub, "sessions")
+      Phoenix.PubSub.subscribe(Livebook.PubSub, "users:#{current_user_id}")
     end
 
+    current_user = Users.fetch!(current_user_id)
     session_summaries = sort_session_summaries(SessionSupervisor.get_session_summaries())
 
-    {:ok, assign(socket, path: default_path(), session_summaries: session_summaries)}
+    {:ok,
+     assign(socket,
+       current_user: current_user,
+       path: default_path(),
+       session_summaries: session_summaries
+     )}
   end
 
   @impl true
   def render(assigns) do
     ~L"""
     <div class="flex flex-grow h-full">
+      <div class="flex flex-col items-center space-y-5 px-3 py-7 bg-gray-900">
+        <div class="flex-grow"></div>
+        <span class="tooltip right distant" aria-label="User profile">
+          <%= live_patch to: Routes.home_path(@socket, :user),
+                class: "text-gray-400 rounded-xl h-8 w-8 flex items-center justify-center" do %>
+            <%= render_user_avatar(@current_user, class: "h-full w-full", text_class: "text-xs") %>
+          <% end %>
+        </span>
+      </div>
       <div class="flex-grow px-6 py-8 overflow-y-auto">
         <div class="max-w-screen-lg w-full mx-auto p-4 pt-0 pb-8 flex flex-col items-center space-y-4">
           <div class="w-full flex flex-col space-y-2 items-center sm:flex-row sm:space-y-0 sm:justify-between sm:pb-4 pb-8 border-b border-gray-200">
@@ -99,6 +117,14 @@ defmodule LivebookWeb.HomeLive do
       </div>
     </div>
 
+    <%= if @live_action == :user do %>
+      <%= live_modal @socket, LivebookWeb.UserComponent,
+            id: :user_modal,
+            modal_class: "w-full max-w-sm",
+            user: @current_user,
+            return_to: Routes.home_path(@socket, :page) %>
+    <% end %>
+
     <%= if @live_action == :close_session do %>
       <%= live_modal @socket, LivebookWeb.HomeLive.CloseSessionComponent,
             id: :close_session_modal,
@@ -179,6 +205,13 @@ defmodule LivebookWeb.HomeLive do
     {notebook, messages} = Livebook.LiveMarkdown.Import.notebook_from_markdown(content)
     socket = put_import_flash_messages(socket, messages)
     create_session(socket, notebook: notebook)
+  end
+
+  def handle_info(
+        {:user_saved, %{id: id} = user},
+        %{assigns: %{current_user: %{id: id}}} = socket
+      ) do
+    {:noreply, assign(socket, :current_user, user)}
   end
 
   def handle_info(_message, socket), do: {:noreply, socket}

--- a/lib/livebook_web/live/live_helpers.ex
+++ b/lib/livebook_web/live/live_helpers.ex
@@ -10,10 +10,10 @@ defmodule LivebookWeb.LiveHelpers do
 
     * `:text_class` - class added to the avatar text
   """
-  def render_user_avatar(name, color, opts \\ []) do
+  def render_user_avatar(user, opts \\ []) do
     assigns = %{
-      name: name,
-      color: color,
+      name: user.name,
+      color: user.color,
       class: Keyword.get(opts, :class, "w-full h-full"),
       text_class: Keyword.get(opts, :text_class)
     }

--- a/lib/livebook_web/live/live_helpers.ex
+++ b/lib/livebook_web/live/live_helpers.ex
@@ -1,0 +1,42 @@
+defmodule LivebookWeb.LiveHelpers do
+  import Phoenix.LiveView.Helpers
+
+  @doc """
+  Renders user avatar,
+
+  ## Options
+
+    * `:class` - class added to the avatar box
+
+    * `:text_class` - class added to the avatar text
+  """
+  def render_user_avatar(name, color, opts \\ []) do
+    assigns = %{
+      name: name,
+      color: color,
+      class: Keyword.get(opts, :class, "w-full h-full"),
+      text_class: Keyword.get(opts, :text_class)
+    }
+
+    ~L"""
+    <div class="rounded-full <%= @class %> flex items-center justify-center" style="background-color: <%= @color %>">
+      <div class="<%= @text_class %> text-gray-100 font-semibold">
+        <%= avatar_text(@name) %>
+      </div>
+    </div>
+    """
+  end
+
+  defp avatar_text(nil), do: "?"
+
+  defp avatar_text(name) do
+    name
+    |> String.split()
+    |> Enum.map(&String.at(&1, 0))
+    |> Enum.map(&String.upcase/1)
+    |> case do
+      [initial] -> initial
+      initials -> List.first(initials) <> List.last(initials)
+    end
+  end
+end

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -216,6 +216,14 @@ defmodule LivebookWeb.SessionLive do
       </div>
     </div>
 
+    <%= if @live_action == :user do %>
+      <%= live_modal @socket, LivebookWeb.UserComponent,
+            id: :user_modal,
+            modal_class: "w-full max-w-sm",
+            user: @current_user,
+            return_to: Routes.session_path(@socket, :page, @session_id) %>
+    <% end %>
+
     <%= if @live_action == :runtime_settings do %>
       <%= live_modal @socket, LivebookWeb.SessionLive.RuntimeComponent,
             id: :runtime_settings_modal,
@@ -259,15 +267,6 @@ defmodule LivebookWeb.SessionLive do
             session_id: @session_id,
             cell: @cell,
             uploads: @uploads,
-            return_to: Routes.session_path(@socket, :page, @session_id) %>
-    <% end %>
-
-    <%= if @live_action == :user do %>
-      <%= live_modal @socket, LivebookWeb.UserComponent,
-            id: :user_modal,
-            modal_class: "w-full max-w-sm",
-            session_id: @session_id,
-            user: @current_user,
             return_to: Routes.session_path(@socket, :page, @session_id) %>
     <% end %>
     """

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -518,7 +518,7 @@ defmodule LivebookWeb.SessionLive do
     {:noreply, push_event(socket, "completion_response", payload)}
   end
 
-  def handle_info({:user_updated, user}, socket) do
+  def handle_info({:user_saved, user}, socket) do
     %{current_user: current_user, users_map: users_map} = socket.assigns
 
     socket =

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -4,11 +4,11 @@ defmodule LivebookWeb.SessionLive do
   alias Livebook.{SessionSupervisor, Session, Delta, Notebook, Runtime}
 
   @impl true
-  def mount(%{"id" => session_id}, _session, socket) do
+  def mount(%{"id" => session_id}, %{"user_id" => user_id}, socket) do
     if SessionSupervisor.session_exists?(session_id) do
       data =
         if connected?(socket) do
-          data = Session.register_client(session_id, self())
+          data = Session.register_client(session_id, {user_id, self()})
           Phoenix.PubSub.subscribe(Livebook.PubSub, "sessions:#{session_id}")
 
           data
@@ -216,7 +216,7 @@ defmodule LivebookWeb.SessionLive do
             return_to: Routes.session_path(@socket, :page, @session_id) %>
     <% end %>
 
-    <%#= if @live_action == :cell_upload do %>
+    <%#= if @live_action == :cell_upload do % >
       <%= live_modal @socket, LivebookWeb.UserComponent,
             id: :user_modal,
             modal_class: "w-full max-w-sm",

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -81,8 +81,13 @@ defmodule LivebookWeb.SessionLive do
           <img src="/logo.png" height="40" width="40" alt="livebook" />
         <% end %>
         <span class="tooltip right distant" aria-label="Sections (ss)">
-          <button class="text-2xl text-gray-400 hover:text-gray-50 focus:text-gray-50 rounded-xl h-10 w-10 flex items-center justify-center" data-element="sections-panel-toggle">
+          <button class="text-2xl text-gray-400 hover:text-gray-50 focus:text-gray-50 rounded-xl h-10 w-10 flex items-center justify-center" data-element="sections-list-toggle">
             <%= remix_icon("booklet-fill") %>
+          </button>
+        </span>
+        <span class="tooltip right distant" aria-label="Connected users (su)">
+          <button class="text-2xl text-gray-400 hover:text-gray-50 focus:text-gray-50 rounded-xl h-10 w-10 flex items-center justify-center" data-element="users-list-toggle">
+            <%= remix_icon("group-fill") %>
           </button>
         </span>
         <span class="tooltip right distant" aria-label="Runtime settings (sr)">
@@ -101,30 +106,52 @@ defmodule LivebookWeb.SessionLive do
         <span class="tooltip right distant" aria-label="User profile">
           <%= live_patch to: Routes.session_path(@socket, :user, @session_id),
                 class: "text-gray-400 rounded-xl h-8 w-8 flex items-center justify-center" do %>
-            <%= render_user_avatar(@current_user.name, @current_user.color, class: "h-full w-full", text_class: "text-xs") %>
+            <%= render_user_avatar(@current_user, class: "h-full w-full", text_class: "text-xs") %>
           <% end %>
         </span>
       </div>
       <div class="flex flex-col h-full w-full max-w-xs absolute z-30 top-0 left-[64px] shadow-xl md:static md:shadow-none overflow-y-auto bg-gray-50 border-r border-gray-100 px-6 py-10"
-        data-element="sections-panel">
-        <div class="flex-grow flex flex-col">
-          <h3 class="font-semibold text-gray-800 text-lg">
-            Sections
-          </h3>
-          <div class="mt-4 flex flex-col space-y-4" data-element="section-list">
-            <%= for section_item <- @data_view.sections_items do %>
-              <button class="text-left hover:text-gray-900 text-gray-500"
-                data-element="section-list-item"
-                data-section-id="<%= section_item.id %>">
-                <%= section_item.name %>
-              </button>
-            <% end %>
+        data-element="side-panel">
+        <div data-element="sections-list">
+          <div class="flex-grow flex flex-col">
+            <h3 class="font-semibold text-gray-800 text-lg">
+              Sections
+            </h3>
+            <div class="mt-4 flex flex-col space-y-4" data-element="section-list">
+              <%= for section_item <- @data_view.sections_items do %>
+                <button class="text-left hover:text-gray-900 text-gray-500"
+                  data-element="section-list-item"
+                  data-section-id="<%= section_item.id %>">
+                  <%= section_item.name %>
+                </button>
+              <% end %>
+            </div>
+            <button class="mt-8 p-8 py-1 text-gray-500 text-sm font-medium rounded-xl border border-gray-400 border-dashed hover:bg-gray-100 inline-flex items-center justify-center space-x-2"
+              phx-click="add_section" >
+              <%= remix_icon("add-line", class: "text-lg align-center") %>
+              <span>New section</span>
+            </button>
           </div>
-          <button class="mt-8 p-8 py-1 text-gray-500 text-sm font-medium rounded-xl border border-gray-400 border-dashed hover:bg-gray-100 inline-flex items-center justify-center space-x-2"
-            phx-click="add_section" >
-            <%= remix_icon("add-line", class: "text-lg align-center") %>
-            <span>New section</span>
-          </button>
+        </div>
+        <div data-element="users-list">
+          <div class="flex-grow flex flex-col">
+            <h3 class="font-semibold text-gray-800 text-lg">
+              Users
+            </h3>
+            <h4 class="font text-gray-500 text-sm my-1">
+              <%= length(@data_view.user_ids) %> connected
+            </h4>
+            <div class="mt-4 flex flex-col space-y-4" data-element="section-list">
+              <%= for user <- get_users(@data_view.user_ids, @users_map) do %>
+                <div class="flex space-x-2 items-center">
+                  <%= render_user_avatar(user, class: "h-7 w-7 flex-shrink-0", text_class: "text-xs") %>
+                  <span class="text-gray-500">
+                    <%= user.name || "Anonymous" %>
+                  </span>
+                </div>
+              <% end %>
+            </div>
+          </div>
         </div>
       </div>
       <div class="flex-grow overflow-y-auto" data-element="notebook">
@@ -244,6 +271,12 @@ defmodule LivebookWeb.SessionLive do
             return_to: Routes.session_path(@socket, :page, @session_id) %>
     <% end %>
     """
+  end
+
+  defp get_users(user_ids, users_map) do
+    user_ids
+    |> Enum.map(&users_map[&1])
+    |> Enum.sort_by(& &1.name)
   end
 
   @impl true
@@ -684,6 +717,7 @@ defmodule LivebookWeb.SessionLive do
         for section <- data.notebook.sections do
           %{id: section.id, name: section.name}
         end,
+      user_ids: Enum.map(data.clients, &elem(&1, 0)),
       section_views: Enum.map(data.notebook.sections, &section_to_view(&1, data))
     }
   end

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -215,6 +215,14 @@ defmodule LivebookWeb.SessionLive do
             uploads: @uploads,
             return_to: Routes.session_path(@socket, :page, @session_id) %>
     <% end %>
+
+    <%#= if @live_action == :cell_upload do %>
+      <%= live_modal @socket, LivebookWeb.UserComponent,
+            id: :user_modal,
+            modal_class: "w-full max-w-sm",
+            session_id: @session_id,
+            return_to: Routes.session_path(@socket, :page, @session_id) %>
+    <%# end %>
     """
   end
 

--- a/lib/livebook_web/live/session_live/attached_live.ex
+++ b/lib/livebook_web/live/session_live/attached_live.ex
@@ -42,12 +42,12 @@ defmodule LivebookWeb.SessionLive.AttachedLive do
       <%= f = form_for :data, "#", phx_submit: "init", phx_change: "validate" %>
         <div class="flex flex-col space-y-4">
           <div>
-            <div class="mb-0.5 text-sm text-gray-800 font-medium">Name</div>
+            <div class="input-label">Name</div>
             <%= text_input f, :name, value: @data["name"], class: "input",
                   placeholder: if(Livebook.Config.shortnames?, do: "test", else: "test@127.0.0.1") %>
           </div>
           <div>
-            <div class="mb-0.5 text-sm text-gray-800 font-medium">Cookie</div>
+            <div class="input-label">Cookie</div>
             <%= text_input f, :cookie, value: @data["cookie"], class: "input", placeholder: "mycookie" %>
           </div>
         </div>

--- a/lib/livebook_web/live/user_component.ex
+++ b/lib/livebook_web/live/user_component.ex
@@ -1,7 +1,7 @@
 defmodule LivebookWeb.UserComponent do
   use LivebookWeb, :live_component
 
-  import LivebookWeb.LiveHelpers
+  import LivebookWeb.UserHelpers
 
   alias Livebook.Users.User
 
@@ -92,7 +92,7 @@ defmodule LivebookWeb.UserComponent do
 
   def handle_event("save", %{"data" => data}, socket) do
     {:ok, user} = User.change(socket.assigns.user, data)
-    Livebook.Users.save(user)
+    Livebook.Users.broadcast_change(user)
     {:noreply, push_patch(socket, to: socket.assigns.return_to)}
   end
 end

--- a/lib/livebook_web/live/user_component.ex
+++ b/lib/livebook_web/live/user_component.ex
@@ -14,7 +14,7 @@ defmodule LivebookWeb.UserComponent do
   end
 
   defp user_to_data(user) do
-    %{"name" => user.name || "", "color" => user.color}
+    %{"name" => user.name || "", "hex_color" => user.hex_color}
   end
 
   @impl true
@@ -42,13 +42,13 @@ defmodule LivebookWeb.UserComponent do
             <div class="input-label">Cursor color</div>
             <div class="flex space-x-4 items-center">
               <div class="border-[3px] rounded-lg p-1 flex justify-center items-center"
-                style="border-color: <%= @preview_user.color %>">
+                style="border-color: <%= @preview_user.hex_color %>">
                 <div class="rounded h-5 w-5"
-                  style="background-color: <%= @preview_user.color %>">
+                  style="background-color: <%= @preview_user.hex_color %>">
                 </div>
               </div>
               <div class="relative flex-grow">
-                <%= text_input f, :color, value: @data["color"], class: "input", spellcheck: "false", maxlength: 7 %>
+                <%= text_input f, :hex_color, value: @data["hex_color"], class: "input", spellcheck: "false", maxlength: 7 %>
                 <%= tag :button, class: "icon-button absolute right-2 top-1",
                       type: "button",
                       phx_click: "randomize_color",
@@ -74,7 +74,7 @@ defmodule LivebookWeb.UserComponent do
   def handle_event("randomize_color", %{}, socket) do
     data = %{
       socket.assigns.data
-      | "color" => User.random_color(except: [socket.assigns.preview_user.color])
+      | "hex_color" => User.random_hex_color(except: [socket.assigns.preview_user.hex_color])
     }
 
     handle_event("validate", %{"data" => data}, socket)

--- a/lib/livebook_web/live/user_component.ex
+++ b/lib/livebook_web/live/user_component.ex
@@ -1,0 +1,109 @@
+defmodule LivebookWeb.UserComponent do
+  use LivebookWeb, :live_component
+
+  @impl true
+  def mount(socket) do
+    {:ok, assign(socket, data: initial_data())}
+  end
+
+  defp initial_data() do
+    # TODO: this should default to current user data, whatever it is!
+    # TODO: user should always have some color by default, how do we handle that?
+    %{"display_name" => "", "color" => random_color()}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~L"""
+    <div class="p-6 flex flex-col space-y-5">
+      <h3 class="text-2xl font-semibold text-gray-800">
+        User config
+      </h3>
+      <div class="flex justify-center">
+        <div class="rounded-full h-20 w-20 flex items-center justify-center" style="background-color: <%= @data["color"] %>">
+          <div class="text-3xl text-gray-100 font-semibold">
+            <%= avatar_text(@data["display_name"]) %>
+          </div>
+        </div>
+      </div>
+      <%= f = form_for :data, "#",
+                phx_target: @myself,
+                phx_submit: "init",
+                phx_change: "validate" %>
+        <div class="flex flex-col space-y-5">
+          <div>
+            <div class="input-label">Display name</div>
+            <%= text_input f, :display_name, value: @data["display_name"], class: "input", spellcheck: "false" %>
+          </div>
+          <div>
+            <div class="input-label">Cursor color</div>
+            <div class="flex space-x-4 items-center">
+              <div class="border-[3px] rounded-lg p-1 flex justify-center items-center"
+                style="border-color: <%= @data["color"] %>">
+                <div class="rounded h-5 w-5"
+                  style="background-color: <%= @data["color"] %>">
+                </div>
+              </div>
+              <div class="relative flex-grow">
+                <%= text_input f, :color, value: @data["color"], class: "input", spellcheck: "false", maxlength: 7 %>
+                <%= tag :button, class: "icon-button absolute right-2 top-1",
+                      type: "button",
+                      phx_click: "randomize_color",
+                      phx_target: @myself %>
+                  <%= remix_icon("refresh-line", class: "text-xl") %>
+                </button>
+              </div>
+            </div>
+          </div>
+          <%= tag :button, class: "button button-blue flex space-x-1 justify-center items-center",
+                type: "submit",
+                disabled: not data_valid?(@data) %>
+            <%= remix_icon("save-line") %>
+            <span>Save</span>
+          </button>
+        </div>
+      </form>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("randomize_color", %{}, socket) do
+    data = %{socket.assigns.data | "color" => random_color()}
+    {:noreply, assign(socket, data: data)}
+  end
+
+  def handle_event("validate", %{"data" => data}, socket) do
+    {:noreply, assign(socket, data: data)}
+  end
+
+  def handle_event("init", %{"data" => data}, socket) do
+    {:noreply, assign(socket, data: data)}
+  end
+
+  defp data_valid?(data) do
+    data["color"] =~ ~r/^#[0-9a-fA-F]{6}$/
+  end
+
+  defp random_color() do
+    # TODO: use HSV and vary H only? or predefined list of neat colors?
+    #   - we want the color to fit white text, so just gather a reasonable list of colors
+    # TODO: also color picker
+    #   - native picker would trigger change too often, we need either a lib
+    #     or something else
+    Enum.random(["#F87171", "#FBBF24", "#6EE7B7", "#60A5FA", "#818CF8", "#A78BFA", "#F472B6"])
+  end
+
+  defp avatar_text(""), do: "?"
+
+  defp avatar_text(display_name) do
+    display_name
+    |> String.split()
+    |> Enum.map(&String.at(&1, 0))
+    |> Enum.map(&String.upcase/1)
+    |> case do
+      [initial] -> initial
+      initials -> List.first(initials) <> List.last(initials)
+    end
+  end
+end

--- a/lib/livebook_web/live/user_component.ex
+++ b/lib/livebook_web/live/user_component.ex
@@ -72,7 +72,11 @@ defmodule LivebookWeb.UserComponent do
 
   @impl true
   def handle_event("randomize_color", %{}, socket) do
-    data = %{socket.assigns.data | "color" => User.random_color()}
+    data = %{
+      socket.assigns.data
+      | "color" => User.random_color(except: [socket.assigns.preview_user.color])
+    }
+
     handle_event("validate", %{"data" => data}, socket)
   end
 

--- a/lib/livebook_web/live/user_component.ex
+++ b/lib/livebook_web/live/user_component.ex
@@ -1,6 +1,8 @@
 defmodule LivebookWeb.UserComponent do
   use LivebookWeb, :live_component
 
+  alias Livebook.Users.User
+
   @impl true
   def mount(socket) do
     {:ok, assign(socket, data: initial_data())}
@@ -9,7 +11,7 @@ defmodule LivebookWeb.UserComponent do
   defp initial_data() do
     # TODO: this should default to current user data, whatever it is!
     # TODO: user should always have some color by default, how do we handle that?
-    %{"display_name" => "", "color" => random_color()}
+    %{"name" => "", "color" => User.random_color()}
   end
 
   @impl true
@@ -22,7 +24,7 @@ defmodule LivebookWeb.UserComponent do
       <div class="flex justify-center">
         <div class="rounded-full h-20 w-20 flex items-center justify-center" style="background-color: <%= @data["color"] %>">
           <div class="text-3xl text-gray-100 font-semibold">
-            <%= avatar_text(@data["display_name"]) %>
+            <%= avatar_text(@data["name"]) %>
           </div>
         </div>
       </div>
@@ -33,7 +35,7 @@ defmodule LivebookWeb.UserComponent do
         <div class="flex flex-col space-y-5">
           <div>
             <div class="input-label">Display name</div>
-            <%= text_input f, :display_name, value: @data["display_name"], class: "input", spellcheck: "false" %>
+            <%= text_input f, :name, value: @data["name"], class: "input", spellcheck: "false" %>
           </div>
           <div>
             <div class="input-label">Cursor color</div>
@@ -69,7 +71,7 @@ defmodule LivebookWeb.UserComponent do
 
   @impl true
   def handle_event("randomize_color", %{}, socket) do
-    data = %{socket.assigns.data | "color" => random_color()}
+    data = %{socket.assigns.data | "color" => User.random_color()}
     {:noreply, assign(socket, data: data)}
   end
 
@@ -85,19 +87,10 @@ defmodule LivebookWeb.UserComponent do
     data["color"] =~ ~r/^#[0-9a-fA-F]{6}$/
   end
 
-  defp random_color() do
-    # TODO: use HSV and vary H only? or predefined list of neat colors?
-    #   - we want the color to fit white text, so just gather a reasonable list of colors
-    # TODO: also color picker
-    #   - native picker would trigger change too often, we need either a lib
-    #     or something else
-    Enum.random(["#F87171", "#FBBF24", "#6EE7B7", "#60A5FA", "#818CF8", "#A78BFA", "#F472B6"])
-  end
-
   defp avatar_text(""), do: "?"
 
-  defp avatar_text(display_name) do
-    display_name
+  defp avatar_text(name) do
+    name
     |> String.split()
     |> Enum.map(&String.at(&1, 0))
     |> Enum.map(&String.upcase/1)

--- a/lib/livebook_web/live/user_component.ex
+++ b/lib/livebook_web/live/user_component.ex
@@ -25,7 +25,7 @@ defmodule LivebookWeb.UserComponent do
         User profile
       </h3>
       <div class="flex justify-center">
-        <%= render_user_avatar(@preview_user.name, @preview_user.color, class: "h-20 w-20", text_class: "text-3xl") %>
+        <%= render_user_avatar(@preview_user, class: "h-20 w-20", text_class: "text-3xl") %>
       </div>
       <%= f = form_for :data, "#",
                 id: "user_form",

--- a/lib/livebook_web/live/user_helpers.ex
+++ b/lib/livebook_web/live/user_helpers.ex
@@ -1,5 +1,8 @@
-defmodule LivebookWeb.LiveHelpers do
+defmodule LivebookWeb.UserHelpers do
+  import Phoenix.LiveView
   import Phoenix.LiveView.Helpers
+
+  alias Livebook.Users.User
 
   @doc """
   Renders user avatar,
@@ -37,6 +40,22 @@ defmodule LivebookWeb.LiveHelpers do
     |> case do
       [initial] -> initial
       initials -> List.first(initials) <> List.last(initials)
+    end
+  end
+
+  @doc """
+  Builds `Livebook.Users.User` with the given user id.
+
+  Uses `user_data` from socket `connect_params` as initial
+  attributes if the socket is connected.
+  """
+  def build_current_user(current_user_id, socket) do
+    connect_params = get_connect_params(socket) || %{}
+    user_data = connect_params["user_data"] || %{}
+
+    case User.change(%{User.new() | id: current_user_id}, user_data) do
+      {:ok, user} -> user
+      {:error, _errors, user} -> user
     end
   end
 end

--- a/lib/livebook_web/live/user_helpers.ex
+++ b/lib/livebook_web/live/user_helpers.ex
@@ -16,13 +16,13 @@ defmodule LivebookWeb.UserHelpers do
   def render_user_avatar(user, opts \\ []) do
     assigns = %{
       name: user.name,
-      color: user.color,
+      hex_color: user.hex_color,
       class: Keyword.get(opts, :class, "w-full h-full"),
       text_class: Keyword.get(opts, :text_class)
     }
 
     ~L"""
-    <div class="rounded-full <%= @class %> flex items-center justify-center" style="background-color: <%= @color %>">
+    <div class="rounded-full <%= @class %> flex items-center justify-center" style="background-color: <%= @hex_color %>">
       <div class="<%= @text_class %> text-gray-100 font-semibold">
         <%= avatar_text(@name) %>
       </div>

--- a/lib/livebook_web/plugs/user_plug.ex
+++ b/lib/livebook_web/plugs/user_plug.ex
@@ -1,0 +1,38 @@
+defmodule LivebookWeb.UserPlug do
+  @moduledoc false
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  alias Livebook.Users
+
+  @impl true
+  def init(opts), do: opts
+
+  @impl true
+  def call(conn, _opts) do
+    with user_id when user_id != nil <- get_session(conn, :user_id),
+         true <- Users.exists?(user_id) do
+      assign(conn, :current_user_id, user_id)
+    else
+      _ ->
+        {:ok, user} = Users.create(get_user_data(conn))
+
+        conn
+        |> put_session(:user_id, user.id)
+        |> assign(:current_user_id, user.id)
+    end
+  end
+
+  defp get_user_data(conn) do
+    # TODO: where to validate?
+    case Map.fetch(conn.req_cookies, "user_data") do
+      {:ok, user_data} ->
+        Jason.decode!(user_data)
+
+      :error ->
+        %{}
+    end
+  end
+end

--- a/lib/livebook_web/plugs/user_plug.ex
+++ b/lib/livebook_web/plugs/user_plug.ex
@@ -18,9 +18,7 @@ defmodule LivebookWeb.UserPlug do
     else
       _ ->
         {:ok, user} = Users.create(get_user_data(conn))
-
-        conn
-        |> put_session(:current_user_id, user.id)
+        put_session(conn, :current_user_id, user.id)
     end
   end
 
@@ -28,7 +26,9 @@ defmodule LivebookWeb.UserPlug do
     # TODO: where to validate?
     case Map.fetch(conn.req_cookies, "user_data") do
       {:ok, user_data} ->
-        Jason.decode!(user_data)
+        user_data = Jason.decode!(user_data)
+        # TODO: handle properly validations etc
+        %{name: user_data["name"], color: user_data["color"]}
 
       :error ->
         %{}

--- a/lib/livebook_web/plugs/user_plug.ex
+++ b/lib/livebook_web/plugs/user_plug.ex
@@ -1,6 +1,17 @@
 defmodule LivebookWeb.UserPlug do
   @moduledoc false
 
+  # Ensures a valid user in the session.
+  #
+  # The first time someone visits Livebook
+  # this plug generates a user for them and stores
+  # the id in the session under `:current_user_id`.
+  #
+  # If the request cookies include `"user_data"` JSON,
+  # this data is used to initialize the new user.
+  # This cookie serves as a decentralized backup of user attributes,
+  # because Livebook doesn't use persistent storage.
+
   @behaviour Plug
 
   import Plug.Conn
@@ -26,7 +37,7 @@ defmodule LivebookWeb.UserPlug do
             {:error, _errors, user} -> user
           end
 
-        Users.save(user)
+        :ok = Users.save(user)
         put_session(conn, :current_user_id, user.id)
     end
   end

--- a/lib/livebook_web/plugs/user_plug.ex
+++ b/lib/livebook_web/plugs/user_plug.ex
@@ -12,16 +12,15 @@ defmodule LivebookWeb.UserPlug do
 
   @impl true
   def call(conn, _opts) do
-    with user_id when user_id != nil <- get_session(conn, :user_id),
+    with user_id when user_id != nil <- get_session(conn, :current_user_id),
          true <- Users.exists?(user_id) do
-      assign(conn, :current_user_id, user_id)
+      conn
     else
       _ ->
         {:ok, user} = Users.create(get_user_data(conn))
 
         conn
-        |> put_session(:user_id, user.id)
-        |> assign(:current_user_id, user.id)
+        |> put_session(:current_user_id, user.id)
     end
   end
 

--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -28,6 +28,7 @@ defmodule LivebookWeb.Router do
     live "/sessions/:id/settings/file", SessionLive, :file_settings
     live "/sessions/:id/cell-settings/:cell_id", SessionLive, :cell_settings
     live "/sessions/:id/cell-upload/:cell_id", SessionLive, :cell_upload
+    live "/sessions/:id/user-profile", SessionLive, :user
     get "/sessions/:id/images/:image", SessionController, :show_image
 
     live_dashboard "/dashboard", metrics: LivebookWeb.Telemetry

--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -13,6 +13,7 @@ defmodule LivebookWeb.Router do
 
   pipeline :auth do
     plug LivebookWeb.AuthPlug
+    plug LivebookWeb.UserPlug
   end
 
   scope "/", LivebookWeb do

--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -20,15 +20,16 @@ defmodule LivebookWeb.Router do
     pipe_through [:browser, :auth]
 
     live "/", HomeLive, :page
+    live "/home/user-profile", HomeLive, :user
     live "/home/import/:tab", HomeLive, :import
     live "/home/sessions/:session_id/close", HomeLive, :close_session
     live "/sessions/:id", SessionLive, :page
+    live "/sessions/:id/user-profile", SessionLive, :user
     live "/sessions/:id/shortcuts", SessionLive, :shortcuts
     live "/sessions/:id/settings/runtime", SessionLive, :runtime_settings
     live "/sessions/:id/settings/file", SessionLive, :file_settings
     live "/sessions/:id/cell-settings/:cell_id", SessionLive, :cell_settings
     live "/sessions/:id/cell-upload/:cell_id", SessionLive, :cell_upload
-    live "/sessions/:id/user-profile", SessionLive, :user
     get "/sessions/:id/images/:image", SessionController, :show_image
 
     live_dashboard "/dashboard", metrics: LivebookWeb.Telemetry

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -72,7 +72,7 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, client_pid},
+          {:client_join, {"u1", client_pid}},
           {:insert_section, self(), 0, "s1"}
         ])
 
@@ -1195,10 +1195,10 @@ defmodule Livebook.Session.DataTest do
     test "returns an error if the given process is already a client" do
       data =
         data_after_operations!([
-          {:client_join, self()}
+          {:client_join, {"u1", self()}}
         ])
 
-      operation = {:client_join, self()}
+      operation = {:client_join, {"u1", self()}}
       assert :error = Data.apply_operation(data, operation)
     end
 
@@ -1206,8 +1206,9 @@ defmodule Livebook.Session.DataTest do
       client_pid = self()
       data = Data.new()
 
-      operation = {:client_join, client_pid}
-      assert {:ok, %{client_pids: [^client_pid]}, []} = Data.apply_operation(data, operation)
+      client = {"u1", client_pid}
+      operation = {:client_join, client}
+      assert {:ok, %{clients: [^client]}, []} = Data.apply_operation(data, operation)
     end
 
     test "adds new entry to the cell revisions map for the client with the latest revision" do
@@ -1216,14 +1217,14 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, client1_pid},
+          {:client_join, {"u1", client1_pid}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", delta1, 1}
         ])
 
       client2_pid = IEx.Helpers.pid(0, 0, 1)
-      operation = {:client_join, client2_pid}
+      operation = {:client_join, {"u2", client2_pid}}
 
       assert {:ok,
               %{
@@ -1236,18 +1237,18 @@ defmodule Livebook.Session.DataTest do
     test "returns an error if the given process is not a client" do
       data = Data.new()
 
-      operation = {:client_leave, self()}
+      operation = {:client_leave, {"u1", self()}}
       assert :error = Data.apply_operation(data, operation)
     end
 
     test "removes the given process from the client list" do
       data =
         data_after_operations!([
-          {:client_join, self()}
+          {:client_join, {"u1", self()}}
         ])
 
-      operation = {:client_leave, self()}
-      assert {:ok, %{client_pids: []}, []} = Data.apply_operation(data, operation)
+      operation = {:client_leave, {"u1", self()}}
+      assert {:ok, %{clients: []}, []} = Data.apply_operation(data, operation)
     end
 
     test "removes an entry in the the cell revisions map for the client and purges deltas" do
@@ -1258,14 +1259,14 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, client1_pid},
-          {:client_join, client2_pid},
+          {:client_join, {"u1", client1_pid}},
+          {:client_join, {"u2", client2_pid}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", delta1, 1}
         ])
 
-      operation = {:client_leave, client2_pid}
+      operation = {:client_leave, {"u2", client2_pid}}
 
       assert {:ok,
               %{
@@ -1282,7 +1283,7 @@ defmodule Livebook.Session.DataTest do
     test "returns an error given invalid cell id" do
       data =
         data_after_operations!([
-          {:client_join, self()}
+          {:client_join, {"u1", self()}}
         ])
 
       operation = {:apply_cell_delta, self(), "nonexistent", Delta.new(), 1}
@@ -1304,7 +1305,7 @@ defmodule Livebook.Session.DataTest do
     test "returns an error given invalid revision" do
       data =
         data_after_operations!([
-          {:client_join, self()},
+          {:client_join, {"u1", self()}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1318,7 +1319,7 @@ defmodule Livebook.Session.DataTest do
     test "updates cell source according to the given delta" do
       data =
         data_after_operations!([
-          {:client_join, self()},
+          {:client_join, {"u1", self()}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1340,7 +1341,7 @@ defmodule Livebook.Session.DataTest do
     test "updates cell digest based on the new content" do
       data =
         data_after_operations!([
-          {:client_join, self()},
+          {:client_join, {"u1", self()}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1364,8 +1365,8 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, client1_pid},
-          {:client_join, client2_pid},
+          {:client_join, {"u1", client1_pid}},
+          {:client_join, {"u2", client2_pid}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", delta1, 1}
@@ -1393,8 +1394,8 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, client1_pid},
-          {:client_join, client2_pid},
+          {:client_join, {"u1", client1_pid}},
+          {:client_join, {"u2", client2_pid}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", delta1, 1}
@@ -1414,7 +1415,7 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, client_pid},
+          {:client_join, {"u1", client_pid}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1434,8 +1435,8 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, client1_pid},
-          {:client_join, client2_pid},
+          {:client_join, {"u1", client1_pid}},
+          {:client_join, {"u2", client2_pid}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1454,7 +1455,7 @@ defmodule Livebook.Session.DataTest do
     test "returns an error given invalid cell id" do
       data =
         data_after_operations!([
-          {:client_join, self()}
+          {:client_join, {"u1", self()}}
         ])
 
       operation = {:report_cell_revision, self(), "nonexistent", 1}
@@ -1467,7 +1468,7 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, client1_pid},
+          {:client_join, {"u1", client1_pid}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", Delta.new(insert: "cats"), 1}
@@ -1480,7 +1481,7 @@ defmodule Livebook.Session.DataTest do
     test "returns an error given invalid revision" do
       data =
         data_after_operations!([
-          {:client_join, self()},
+          {:client_join, {"u1", self()}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1497,8 +1498,8 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, client1_pid},
-          {:client_join, client2_pid},
+          {:client_join, {"u1", client1_pid}},
+          {:client_join, {"u2", client2_pid}},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", delta1, 1}

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -3,6 +3,7 @@ defmodule Livebook.Session.DataTest do
 
   alias Livebook.Session.Data
   alias Livebook.{Delta, Notebook}
+  alias Livebook.Users.User
 
   describe "new/1" do
     test "called with no arguments defaults to a blank notebook" do
@@ -72,7 +73,7 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, {"u1", client_pid}},
+          {:client_join, client_pid, User.new()},
           {:insert_section, self(), 0, "s1"}
         ])
 
@@ -1193,38 +1194,43 @@ defmodule Livebook.Session.DataTest do
 
   describe "apply_operation/2 given :client_join" do
     test "returns an error if the given process is already a client" do
+      user = User.new()
+
       data =
         data_after_operations!([
-          {:client_join, {"u1", self()}}
+          {:client_join, self(), user}
         ])
 
-      operation = {:client_join, {"u1", self()}}
+      operation = {:client_join, self(), user}
       assert :error = Data.apply_operation(data, operation)
     end
 
-    test "adds the given process to the client list" do
+    test "adds the given process and user to their corresponding maps" do
       client_pid = self()
+      %{id: user_id} = user = User.new()
       data = Data.new()
 
-      client = {"u1", client_pid}
-      operation = {:client_join, client}
-      assert {:ok, %{clients: [^client]}, []} = Data.apply_operation(data, operation)
+      operation = {:client_join, client_pid, user}
+
+      assert {:ok, %{clients_map: %{^client_pid => ^user_id}, users_map: %{^user_id => ^user}},
+              []} = Data.apply_operation(data, operation)
     end
 
     test "adds new entry to the cell revisions map for the client with the latest revision" do
       client1_pid = IEx.Helpers.pid(0, 0, 0)
+      user = User.new()
       delta1 = Delta.new() |> Delta.insert("cats")
 
       data =
         data_after_operations!([
-          {:client_join, {"u1", client1_pid}},
+          {:client_join, client1_pid, user},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", delta1, 1}
         ])
 
       client2_pid = IEx.Helpers.pid(0, 0, 1)
-      operation = {:client_join, {"u2", client2_pid}}
+      operation = {:client_join, client2_pid, user}
 
       assert {:ok,
               %{
@@ -1237,18 +1243,48 @@ defmodule Livebook.Session.DataTest do
     test "returns an error if the given process is not a client" do
       data = Data.new()
 
-      operation = {:client_leave, {"u1", self()}}
+      operation = {:client_leave, self()}
       assert :error = Data.apply_operation(data, operation)
     end
 
-    test "removes the given process from the client list" do
+    test "removes the given process from the client map" do
       data =
         data_after_operations!([
-          {:client_join, {"u1", self()}}
+          {:client_join, self(), User.new()}
         ])
 
-      operation = {:client_leave, {"u1", self()}}
-      assert {:ok, %{clients: []}, []} = Data.apply_operation(data, operation)
+      operation = {:client_leave, self()}
+
+      empty_map = %{}
+      assert {:ok, %{clients_map: ^empty_map}, []} = Data.apply_operation(data, operation)
+    end
+
+    test "removes the corresponding user from users map if it has no more client processes" do
+      data =
+        data_after_operations!([
+          {:client_join, self(), User.new()}
+        ])
+
+      operation = {:client_leave, self()}
+
+      empty_map = %{}
+      assert {:ok, %{users_map: ^empty_map}, []} = Data.apply_operation(data, operation)
+    end
+
+    test "leaves the corresponding user in users map if it has more client processes" do
+      %{id: user_id} = user = User.new()
+      client1_pid = IEx.Helpers.pid(0, 0, 0)
+      client2_pid = IEx.Helpers.pid(0, 0, 1)
+
+      data =
+        data_after_operations!([
+          {:client_join, client1_pid, user},
+          {:client_join, client2_pid, user}
+        ])
+
+      operation = {:client_leave, client2_pid}
+
+      assert {:ok, %{users_map: %{^user_id => ^user}}, []} = Data.apply_operation(data, operation)
     end
 
     test "removes an entry in the the cell revisions map for the client and purges deltas" do
@@ -1259,14 +1295,14 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, {"u1", client1_pid}},
-          {:client_join, {"u2", client2_pid}},
+          {:client_join, client1_pid, User.new()},
+          {:client_join, client2_pid, User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", delta1, 1}
         ])
 
-      operation = {:client_leave, {"u2", client2_pid}}
+      operation = {:client_leave, client2_pid}
 
       assert {:ok,
               %{
@@ -1279,11 +1315,35 @@ defmodule Livebook.Session.DataTest do
     end
   end
 
+  describe "apply_operation/2 given :update_user" do
+    test "returns an error if the given user is not a client" do
+      data = Data.new()
+
+      operation = {:update_user, self(), User.new()}
+      assert :error = Data.apply_operation(data, operation)
+    end
+
+    test "updates users map" do
+      %{id: user_id} = user = User.new()
+
+      data =
+        data_after_operations!([
+          {:client_join, self(), user}
+        ])
+
+      updated_user = %{user | name: "Jake Peralta"}
+      operation = {:update_user, self(), updated_user}
+
+      assert {:ok, %{users_map: %{^user_id => ^updated_user}}, []} =
+               Data.apply_operation(data, operation)
+    end
+  end
+
   describe "apply_operation/2 given :apply_cell_delta" do
     test "returns an error given invalid cell id" do
       data =
         data_after_operations!([
-          {:client_join, {"u1", self()}}
+          {:client_join, self(), User.new()}
         ])
 
       operation = {:apply_cell_delta, self(), "nonexistent", Delta.new(), 1}
@@ -1305,7 +1365,7 @@ defmodule Livebook.Session.DataTest do
     test "returns an error given invalid revision" do
       data =
         data_after_operations!([
-          {:client_join, {"u1", self()}},
+          {:client_join, self(), User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1319,7 +1379,7 @@ defmodule Livebook.Session.DataTest do
     test "updates cell source according to the given delta" do
       data =
         data_after_operations!([
-          {:client_join, {"u1", self()}},
+          {:client_join, self(), User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1341,7 +1401,7 @@ defmodule Livebook.Session.DataTest do
     test "updates cell digest based on the new content" do
       data =
         data_after_operations!([
-          {:client_join, {"u1", self()}},
+          {:client_join, self(), User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1365,8 +1425,8 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, {"u1", client1_pid}},
-          {:client_join, {"u2", client2_pid}},
+          {:client_join, client1_pid, User.new()},
+          {:client_join, client2_pid, User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", delta1, 1}
@@ -1394,8 +1454,8 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, {"u1", client1_pid}},
-          {:client_join, {"u2", client2_pid}},
+          {:client_join, client1_pid, User.new()},
+          {:client_join, client2_pid, User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", delta1, 1}
@@ -1415,7 +1475,7 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, {"u1", client_pid}},
+          {:client_join, client_pid, User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1435,8 +1495,8 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, {"u1", client1_pid}},
-          {:client_join, {"u2", client2_pid}},
+          {:client_join, client1_pid, User.new()},
+          {:client_join, client2_pid, User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1455,7 +1515,7 @@ defmodule Livebook.Session.DataTest do
     test "returns an error given invalid cell id" do
       data =
         data_after_operations!([
-          {:client_join, {"u1", self()}}
+          {:client_join, self(), User.new()}
         ])
 
       operation = {:report_cell_revision, self(), "nonexistent", 1}
@@ -1468,7 +1528,7 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, {"u1", client1_pid}},
+          {:client_join, client1_pid, User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", Delta.new(insert: "cats"), 1}
@@ -1481,7 +1541,7 @@ defmodule Livebook.Session.DataTest do
     test "returns an error given invalid revision" do
       data =
         data_after_operations!([
-          {:client_join, {"u1", self()}},
+          {:client_join, self(), User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"}
         ])
@@ -1498,8 +1558,8 @@ defmodule Livebook.Session.DataTest do
 
       data =
         data_after_operations!([
-          {:client_join, {"u1", client1_pid}},
-          {:client_join, {"u2", client2_pid}},
+          {:client_join, client1_pid, User.new()},
+          {:client_join, client2_pid, User.new()},
           {:insert_section, self(), 0, "s1"},
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:apply_cell_delta, client1_pid, "c1", delta1, 1}

--- a/test/livebook/users/user_test.exs
+++ b/test/livebook/users/user_test.exs
@@ -1,0 +1,34 @@
+defmodule Livebook.Users.UserTest do
+  use ExUnit.Case, async: true
+
+  alias Livebook.Users.User
+
+  describe "change/2" do
+    test "given valid attributes returns and updated user" do
+      user = User.new()
+      attrs = %{"name" => "Jake Peralta", "color" => "#000000"}
+      assert {:ok, %User{name: "Jake Peralta", color: "#000000"}} = User.change(user, attrs)
+    end
+
+    test "given empty name sets name to nil" do
+      user = User.new()
+      attrs = %{"name" => ""}
+      assert {:ok, %User{name: nil}} = User.change(user, attrs)
+    end
+
+    test "given invalid color returns an error" do
+      user = User.new()
+      attrs = %{"color" => "#invalid"}
+      assert {:error, [{:color, "not a valid color"}], _user} = User.change(user, attrs)
+    end
+
+    test "given invalid attribute partially updates the user" do
+      user = User.new()
+      current_color = user.color
+      attrs = %{"color" => "#invalid", "name" => "Jake Peralta"}
+
+      assert {:error, _errors, %User{name: "Jake Peralta", color: ^current_color}} =
+               User.change(user, attrs)
+    end
+  end
+end

--- a/test/livebook/users/user_test.exs
+++ b/test/livebook/users/user_test.exs
@@ -6,8 +6,8 @@ defmodule Livebook.Users.UserTest do
   describe "change/2" do
     test "given valid attributes returns and updated user" do
       user = User.new()
-      attrs = %{"name" => "Jake Peralta", "color" => "#000000"}
-      assert {:ok, %User{name: "Jake Peralta", color: "#000000"}} = User.change(user, attrs)
+      attrs = %{"name" => "Jake Peralta", "hex_color" => "#000000"}
+      assert {:ok, %User{name: "Jake Peralta", hex_color: "#000000"}} = User.change(user, attrs)
     end
 
     test "given empty name sets name to nil" do
@@ -18,16 +18,16 @@ defmodule Livebook.Users.UserTest do
 
     test "given invalid color returns an error" do
       user = User.new()
-      attrs = %{"color" => "#invalid"}
-      assert {:error, [{:color, "not a valid color"}], _user} = User.change(user, attrs)
+      attrs = %{"hex_color" => "#invalid"}
+      assert {:error, [{:hex_color, "not a valid color"}], _user} = User.change(user, attrs)
     end
 
     test "given invalid attribute partially updates the user" do
       user = User.new()
-      current_color = user.color
-      attrs = %{"color" => "#invalid", "name" => "Jake Peralta"}
+      current_hex_color = user.hex_color
+      attrs = %{"hex_color" => "#invalid", "name" => "Jake Peralta"}
 
-      assert {:error, _errors, %User{name: "Jake Peralta", color: ^current_color}} =
+      assert {:error, _errors, %User{name: "Jake Peralta", hex_color: ^current_hex_color}} =
                User.change(user, attrs)
     end
   end

--- a/test/livebook/users_test.exs
+++ b/test/livebook/users_test.exs
@@ -1,0 +1,60 @@
+defmodule Livebook.UsersTest do
+  use ExUnit.Case, async: true
+
+  alias Livebook.Users
+  alias Livebook.Users.User
+
+  describe "save/1" do
+    test "inserts a new user if they don't exist" do
+      user = User.new()
+      :ok = Users.save(user)
+      assert Users.fetch!(user.id) == user
+    end
+
+    test "updates the user if they do exist" do
+      user = User.new()
+      :ok = Users.save(user)
+
+      updated_user = %{user | name: "Jake Peralta"}
+      :ok = Users.save(updated_user)
+      assert Users.fetch!(user.id) == updated_user
+    end
+  end
+
+  describe "exists?/1" do
+    test "returns true if the user exists" do
+      user = User.new()
+      :ok = Users.save(user)
+      assert Users.exists?(user.id)
+    end
+
+    test "returns false if the user does not exist" do
+      refute Users.exists?("nonexistent")
+    end
+  end
+
+  describe "fetch!/1" do
+    test "raises an error if no user with the given id exists" do
+      assert_raise RuntimeError, fn ->
+        Users.fetch!("nonexistent")
+      end
+    end
+  end
+
+  describe "list_by_ids/1" do
+    test "returns an empty list if no user matches the given ids" do
+      assert Users.list_by_ids(["nonexistent1", "nonexistent2"]) == []
+    end
+
+    test "returns users matching the given ids" do
+      user1 = User.new()
+      user2 = User.new()
+      user3 = User.new()
+
+      for user <- [user1, user2, user3], do: :ok = Users.save(user)
+
+      assert Users.list_by_ids([user1.id, user3.id]) |> Enum.sort() ==
+               [user1, user3] |> Enum.sort()
+    end
+  end
+end

--- a/test/livebook/users_test.exs
+++ b/test/livebook/users_test.exs
@@ -4,57 +4,14 @@ defmodule Livebook.UsersTest do
   alias Livebook.Users
   alias Livebook.Users.User
 
-  describe "save/1" do
-    test "inserts a new user if they don't exist" do
+  describe "broadcast_change/1" do
+    test "notifies subscribers of user change" do
       user = User.new()
-      :ok = Users.save(user)
-      assert Users.fetch!(user.id) == user
-    end
+      Phoenix.PubSub.subscribe(Livebook.PubSub, "users:#{user.id}")
 
-    test "updates the user if they do exist" do
-      user = User.new()
-      :ok = Users.save(user)
+      Users.broadcast_change(user)
 
-      updated_user = %{user | name: "Jake Peralta"}
-      :ok = Users.save(updated_user)
-      assert Users.fetch!(user.id) == updated_user
-    end
-  end
-
-  describe "exists?/1" do
-    test "returns true if the user exists" do
-      user = User.new()
-      :ok = Users.save(user)
-      assert Users.exists?(user.id)
-    end
-
-    test "returns false if the user does not exist" do
-      refute Users.exists?("nonexistent")
-    end
-  end
-
-  describe "fetch!/1" do
-    test "raises an error if no user with the given id exists" do
-      assert_raise RuntimeError, fn ->
-        Users.fetch!("nonexistent")
-      end
-    end
-  end
-
-  describe "list_by_ids/1" do
-    test "returns an empty list if no user matches the given ids" do
-      assert Users.list_by_ids(["nonexistent1", "nonexistent2"]) == []
-    end
-
-    test "returns users matching the given ids" do
-      user1 = User.new()
-      user2 = User.new()
-      user3 = User.new()
-
-      for user <- [user1, user2, user3], do: :ok = Users.save(user)
-
-      assert Users.list_by_ids([user1.id, user3.id]) |> Enum.sort() ==
-               [user1, user3] |> Enum.sort()
+      assert_received {:user_change, ^user}
     end
   end
 end

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -3,7 +3,8 @@ defmodule LivebookWeb.SessionLiveTest do
 
   import Phoenix.LiveViewTest
 
-  alias Livebook.{SessionSupervisor, Session, Delta, Runtime}
+  alias Livebook.{SessionSupervisor, Session, Delta, Runtime, Users}
+  alias Livebook.Users.User
 
   setup do
     {:ok, session_id} = SessionSupervisor.create_session()
@@ -270,6 +271,77 @@ defmodule LivebookWeb.SessionLiveTest do
     assert render(view) =~ "My notebook - fork"
   end
 
+  describe "connected users" do
+    test "lists connected users", %{conn: conn, session_id: session_id} do
+      user1 = create_user_with_name("Jake Peralta")
+
+      client_pid =
+        spawn_link(fn ->
+          Session.register_client(session_id, {user1.id, self()})
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      {:ok, view, _} = live(conn, "/sessions/#{session_id}")
+
+      assert render(view) =~ "Jake Peralta"
+
+      send(client_pid, :stop)
+    end
+
+    test "updates users list whenever a user joins or leaves",
+         %{conn: conn, session_id: session_id} do
+      {:ok, view, _} = live(conn, "/sessions/#{session_id}")
+
+      Phoenix.PubSub.subscribe(Livebook.PubSub, "sessions:#{session_id}")
+
+      user1 = create_user_with_name("Jake Peralta")
+
+      client_pid =
+        spawn_link(fn ->
+          Session.register_client(session_id, {user1.id, self()})
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      assert_receive {:operation, {:client_join, {_user_id, ^client_pid}}}
+      assert render(view) =~ "Jake Peralta"
+
+      send(client_pid, :stop)
+      assert_receive {:operation, {:client_leave, {_user_id, ^client_pid}}}
+      refute render(view) =~ "Jake Peralta"
+    end
+
+    test "updates users list whenever a user changes his data",
+         %{conn: conn, session_id: session_id} do
+      user1 = create_user_with_name("Jake Peralta")
+
+      client_pid =
+        spawn_link(fn ->
+          Session.register_client(session_id, {user1.id, self()})
+
+          receive do
+            :stop -> :ok
+          end
+        end)
+
+      {:ok, view, _} = live(conn, "/sessions/#{session_id}")
+
+      assert render(view) =~ "Jake Peralta"
+
+      :ok = Users.save(%{user1 | name: "Raymond Holt"})
+
+      refute render(view) =~ "Jake Peralta"
+      assert render(view) =~ "Raymond Holt"
+
+      send(client_pid, :stop)
+    end
+  end
+
   # Helpers
 
   defp wait_for_session_update(session_id) do
@@ -296,5 +368,11 @@ defmodule LivebookWeb.SessionLiveTest do
     Session.apply_cell_delta(session_id, cell.id, delta, 1)
 
     cell.id
+  end
+
+  defp create_user_with_name(name) do
+    {:ok, user} = User.new() |> User.change(%{"name" => name})
+    :ok = Users.save(user)
+    user
   end
 end

--- a/test/livebook_web/plugs/user_plug_test.exs
+++ b/test/livebook_web/plugs/user_plug_test.exs
@@ -2,56 +2,50 @@ defmodule LivebookWeb.UserPlugTest do
   use ExUnit.Case, async: true
   use Plug.Test
 
-  alias Livebook.Users
-  alias Livebook.Users.User
-
   defp call(conn) do
     LivebookWeb.UserPlug.call(conn, LivebookWeb.UserPlug.init([]))
   end
 
-  test "given no user id in the session, generates a new user" do
+  test "given no user id in the session, generates a new user id" do
     conn =
       conn(:get, "/")
       |> init_test_session(%{})
       |> call()
 
-    user_id = get_session(conn, :current_user_id)
-    assert Users.exists?(user_id)
+    assert get_session(conn, :current_user_id) != nil
   end
 
-  test "given no user id in the session, uses user_data cookie if present" do
+  test "keeps user id in the session if present" do
+    conn =
+      conn(:get, "/")
+      |> init_test_session(%{current_user_id: "valid_user_id"})
+      |> call()
+
+    assert get_session(conn, :current_user_id) != nil
+  end
+
+  test "given no user_data cookie, generates and stores new data" do
     conn =
       conn(:get, "/")
       |> init_test_session(%{})
-      |> put_req_cookie("user_data", ~s/{"name":"Jake Peralta","color":"#000000"}/)
       |> fetch_cookies()
       |> call()
+      |> fetch_cookies()
 
-    user_id = get_session(conn, :current_user_id)
-    assert %User{name: "Jake Peralta", color: "#000000"} = Users.fetch!(user_id)
+    assert conn.cookies["user_data"] != nil
   end
 
-  test "given nonexistent user id in the session, generates a new user" do
-    conn =
-      conn(:get, "/")
-      |> init_test_session(%{current_user_id: "no_longer_valid"})
-      |> call()
-
-    user_id = get_session(conn, :current_user_id)
-    assert user_id != "no_longer_valid"
-    assert Users.exists?(user_id)
-  end
-
-  test "given existing user id in the session, keeps it" do
-    user = User.new()
-    Users.save(user)
+  test "keeps user_data cookie if present" do
+    cookie_value = ~s/{"name":"Jake Peralta","color":"#000000"}/
 
     conn =
       conn(:get, "/")
-      |> init_test_session(%{current_user_id: user.id})
+      |> init_test_session(%{})
+      |> put_req_cookie("user_data", cookie_value)
+      |> fetch_cookies()
       |> call()
+      |> fetch_cookies()
 
-    user_id = get_session(conn, :current_user_id)
-    assert user_id == user.id
+    assert conn.cookies["user_data"] == cookie_value
   end
 end

--- a/test/livebook_web/plugs/user_plug_test.exs
+++ b/test/livebook_web/plugs/user_plug_test.exs
@@ -1,0 +1,57 @@
+defmodule LivebookWeb.UserPlugTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Livebook.Users
+  alias Livebook.Users.User
+
+  defp call(conn) do
+    LivebookWeb.UserPlug.call(conn, LivebookWeb.UserPlug.init([]))
+  end
+
+  test "given no user id in the session, generates a new user" do
+    conn =
+      conn(:get, "/")
+      |> init_test_session(%{})
+      |> call()
+
+    user_id = get_session(conn, :current_user_id)
+    assert Users.exists?(user_id)
+  end
+
+  test "given no user id in the session, uses user_data cookie if present" do
+    conn =
+      conn(:get, "/")
+      |> init_test_session(%{})
+      |> put_req_cookie("user_data", ~s/{"name":"Jake Peralta","color":"#000000"}/)
+      |> fetch_cookies()
+      |> call()
+
+    user_id = get_session(conn, :current_user_id)
+    assert %User{name: "Jake Peralta", color: "#000000"} = Users.fetch!(user_id)
+  end
+
+  test "given nonexistent user id in the session, generates a new user" do
+    conn =
+      conn(:get, "/")
+      |> init_test_session(%{current_user_id: "no_longer_valid"})
+      |> call()
+
+    user_id = get_session(conn, :current_user_id)
+    assert user_id != "no_longer_valid"
+    assert Users.exists?(user_id)
+  end
+
+  test "given existing user id in the session, keeps it" do
+    user = User.new()
+    Users.save(user)
+
+    conn =
+      conn(:get, "/")
+      |> init_test_session(%{current_user_id: user.id})
+      |> call()
+
+    user_id = get_session(conn, :current_user_id)
+    assert user_id == user.id
+  end
+end

--- a/test/livebook_web/plugs/user_plug_test.exs
+++ b/test/livebook_web/plugs/user_plug_test.exs
@@ -36,7 +36,7 @@ defmodule LivebookWeb.UserPlugTest do
   end
 
   test "keeps user_data cookie if present" do
-    cookie_value = ~s/{"name":"Jake Peralta","color":"#000000"}/
+    cookie_value = ~s/{"name":"Jake Peralta","hex_color":"#000000"}/
 
     conn =
       conn(:get, "/")


### PR DESCRIPTION
This is the first part of #59 (user profiles and presence). I will address cursors separately as the PR is already pretty huge. One other thing missing here is a more fancy color picker, but that's also an independent change.

## Design

In Livebook users don't represent accounts, instead a user is effectively a person using a browser. Consequently every request is assumed to come from *some* user. The new `UserPlug` makes sure we always have `:current_user_id` in the session. It also ensures that the `"user_data"` cookie contains some information, if that's not the case it generates and stores new data.

From client we use `LiveSocket#params` callback to always provide the latest `user_data` from the cookie. Then in LiveViews we get this information from socket `connect_params`, and together with `:current_user_id` from session we use it to build the current user struct. Additionally whenever the user saves his data via form we update the `"user_data"` cookie.

`Data` now keeps track of users, so we no longer need a synchronized central storage. `Session` subscribes to `users:id` topic for every relevant user and then triggers the `{:update_user, user}` operation to update `Data` everywhere accordingly. With this approach everything should work as expected in multi-node deployment, because we have a single source of truth (users for every session).

## Demo

https://user-images.githubusercontent.com/17034772/116741263-65ce4d00-a9f6-11eb-96a2-47e2b90285a8.mp4

