### PR TITLE
Use a node pool for node names

### DIFF
--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -18,10 +18,10 @@ defmodule Livebook.Application do
       Livebook.SessionSupervisor,
       # Start the server responsible for associating files with sessions
       Livebook.Session.FileGuard,
-      # Start the Endpoint (http/https)
-      LivebookWeb.Endpoint,
       # Start the Node Pool for managing node names
-      Livebook.Runtime.NodePool
+      Livebook.Runtime.NodePool,
+      # Start the Endpoint (http/https)
+      LivebookWeb.Endpoint
     ]
 
     opts = [strategy: :one_for_one, name: Livebook.Supervisor]

--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -19,7 +19,9 @@ defmodule Livebook.Application do
       # Start the server responsible for associating files with sessions
       Livebook.Session.FileGuard,
       # Start the Endpoint (http/https)
-      LivebookWeb.Endpoint
+      LivebookWeb.Endpoint,
+      # Start the Node Pool for managing node names
+      Livebook.Runtime.NodePool
     ]
 
     opts = [strategy: :one_for_one, name: Livebook.Supervisor]

--- a/lib/livebook/runtime/node_pool.ex
+++ b/lib/livebook/runtime/node_pool.ex
@@ -59,7 +59,7 @@ defmodule Livebook.Runtime.NodePool do
 
   @impl GenServer
   def handle_info({:nodedown, node, _info}, state) do
-    {:ok, _} = :timer.send_after(state.buffer_time, __MODULE__, {:add_node, node})
+    _ = Process.send_after(self(), {:add_node, node}, state.buffer_time)
     {:noreply, state}
   end
 

--- a/lib/livebook/runtime/node_pool.ex
+++ b/lib/livebook/runtime/node_pool.ex
@@ -90,7 +90,7 @@ defmodule Livebook.Runtime.NodePool do
   end
 
   defp get_existing_name(state) do
-    {name, free_names} = List.pop_at(state.free_names, 0)
+    [name | free_names] = state.free_names
     {name, %{state | free_names: free_names}}
   end
 

--- a/lib/livebook/runtime/node_pool.ex
+++ b/lib/livebook/runtime/node_pool.ex
@@ -1,0 +1,84 @@
+defmodule Livebook.Runtime.NodePool do
+  use GenServer, async: false
+
+  # A pool for reusing child node names.
+  #
+  # `pool` refers to the list of unused names
+  #
+  # `buffer_time` refers to time the pool waits before
+  # adding a name to `pool`,  which by default is 1 minute.
+
+  @default_time 6_000
+
+  # Client interface
+
+  @doc """
+  Starts the node pool with the buffer time as 1 minute.
+  """
+  def start do
+    GenServer.start(__MODULE__, @default_time, name: __MODULE__)
+  end
+
+  @doc """
+  Starts the node pool with the buffer time as input.
+  """
+  def start(buffer_time) do
+    GenServer.start(__MODULE__, buffer_time, name: __MODULE__)
+  end
+
+  @doc """
+  Retuns a node name.
+
+  Generates a new one if node is empty, or takes on from pool.
+  """
+  def get_name(parent) do
+    GenServer.call(__MODULE__, {:get_name, parent})
+  end
+
+  # Server side code
+
+  @impl GenServer
+  def init(buffer_time) do
+    :net_kernel.monitor_nodes(true)
+    {:ok, %{pool: [], buffer_time: buffer_time}}
+  end
+
+  @impl GenServer
+  def handle_call({:get_name, parent}, _, state) do
+    {:reply, name(state, parent), state}
+  end
+
+  @impl GenServer
+  def handle_info({:nodeup, node}, state) do
+    {:noreply, remove_node(state, node)}
+  end
+
+  @impl GenServer
+  def handle_info({:nodedown, node}, state) do
+    {:ok, _TRef} = :timer.send_after(state.buffer_time, __MODULE__, {:add_node, node})
+    {:noreply, state}
+  end
+
+  @impl GenServer
+  def handle_info({:add_node, node}, state) do
+    {:noreply, add_node(state, node)}
+  end
+
+  # Helper functions
+
+  defp name(state, parent) do
+    if Enum.empty?(state.pool) do
+      :"#{Livebook.Utils.random_short_id()}-#{parent}"
+    else
+      hd(state.pool)
+    end
+  end
+
+  defp remove_node(state, node) do
+    %{state | pool: List.delete(state.pool, node)}
+  end
+
+  defp add_node(state, node) do
+    %{state | pool: [node | state.pool]}
+  end
+end

--- a/lib/livebook/runtime/standalone_init.ex
+++ b/lib/livebook/runtime/standalone_init.ex
@@ -5,15 +5,20 @@ defmodule Livebook.Runtime.StandaloneInit do
   # a new Elixir system process. It's used by both ElixirStandalone
   # and MixStandalone runtimes.
 
-  alias Livebook.Utils
   alias Livebook.Utils.Emitter
+  alias Livebook.Runtime.NodePool
 
   @doc """
   Returns a random name for a dynamically spawned node.
   """
   @spec child_node_name(atom()) :: atom()
   def child_node_name(parent) do
-    :"#{Utils.random_short_id()}-#{parent}"
+    if Process.whereis(NodePool) do
+      NodePool.get_name(parent)
+    else
+      NodePool.start()
+      NodePool.get_name(parent)
+    end
   end
 
   @doc """

--- a/lib/livebook/runtime/standalone_init.ex
+++ b/lib/livebook/runtime/standalone_init.ex
@@ -13,12 +13,7 @@ defmodule Livebook.Runtime.StandaloneInit do
   """
   @spec child_node_name(atom()) :: atom()
   def child_node_name(parent) do
-    if Process.whereis(NodePool) do
-      NodePool.get_name(parent)
-    else
-      NodePool.start()
-      NodePool.get_name(parent)
-    end
+    NodePool.get_name(parent)
   end
 
   @doc """

--- a/test/livebook/runtime/node_pool_test.exs
+++ b/test/livebook/runtime/node_pool_test.exs
@@ -36,6 +36,10 @@ defmodule Livebook.Runtime.NodePoolTest do
       name = NodePool.get_name(config.test, node())
       send(config.test, {:nodedown, name, {}})
 
+      # Since we want the `:add_node` message  processed first
+      # before we call `get_name`, we wait
+      Process.sleep(1)
+
       assert NodePool.get_name(config.test, node()) == name
     end
 
@@ -44,6 +48,10 @@ defmodule Livebook.Runtime.NodePoolTest do
 
       name = NodePool.get_name(config.test, node())
       send(config.test, {:nodedown, name, {}})
+
+      # Since we want the `:add_node` message  processed first
+      # before we call `get_name`, we wait
+      Process.sleep(1)
 
       name = NodePool.get_name(config.test, node())
       assert NodePool.get_name(config.test, node()) != name
@@ -56,6 +64,10 @@ defmodule Livebook.Runtime.NodePoolTest do
 
       # Mock a nodedown
       send(config.test, {:nodedown, :some_foo, {}})
+
+      # Since we want the `:add_node` message  processed first
+      # before we call `get_name`, we wait
+      Process.sleep(1)
 
       # Verify that name is not in pool, by calling get_name/2
       assert NodePool.get_name(config.test, node()) != :some_foo

--- a/test/livebook/runtime/node_pool_test.exs
+++ b/test/livebook/runtime/node_pool_test.exs
@@ -1,0 +1,121 @@
+defmodule Livebook.Runtime.NodePoolTest do
+  use ExUnit.Case, async: true
+
+  alias Livebook.Runtime.NodePool
+
+  # Tests for Livebook.Runtime.NodePool
+  #
+  # Note:
+  # 1. We do not spawn actual nodes as it can be time
+  #    intensive (on low spec machines)
+  #
+  # 2. We wait a certain period of time after we mock
+  #    a node down, so that the buffer period is spent,
+  #    and the node is added to pool.
+
+  describe "start" do
+    test "/0 correctly starts a registered GenServer" do
+      NodePool.start()
+
+      # Verify Process is running
+      assert Process.whereis(NodePool)
+
+      GenServer.stop(NodePool)
+    end
+
+    test "/1 correctly starts a registered GenServer with correct buffer time" do
+      NodePool.start(1)
+
+      # Verify Process is running
+      assert Process.whereis(NodePool)
+
+      # Verify buffer time
+      state = :sys.get_state(NodePool)
+      assert state.buffer_time == 1
+
+      GenServer.stop(NodePool)
+    end
+  end
+
+  describe "get_name/1" do
+    test "creates a new node name if pool is empty" do
+      NodePool.start()
+
+      # Verify pool is empty
+      assert empty?()
+
+      # Assert that we get a result and that it is an atom
+      result = NodePool.get_name(node())
+      assert result
+      assert is_atom(result)
+      GenServer.stop(NodePool)
+    end
+
+    test "returns an existing name if pool is not empty" do
+      NodePool.start(1)
+
+      # Mock a node down
+      send(NodePool, {:nodedown, :foobar})
+      Process.sleep(5)
+
+      assert contains?(:foobar)
+
+      assert NodePool.get_name(node()) == :foobar
+      GenServer.stop(NodePool)
+    end
+  end
+
+  test "On nodeup removes pooled name accordingly" do
+    NodePool.start(1)
+
+    # Mock a node down and up
+    send(NodePool, {:nodedown, :foobar})
+    Process.sleep(5)
+    send(NodePool, {:nodeup, :foobar})
+
+    # Assert that atom `:foobar` is not in pool
+    assert not contains?(:foobar)
+
+    GenServer.stop(NodePool)
+  end
+
+  describe "On nodedown" do
+    test "adds node name to pool" do
+      NodePool.start(1)
+
+      # Mock a nodedown
+      send(NodePool, {:nodedown, :janfu})
+      Process.sleep(5)
+
+      # Verify that atom `:janfu` is in pool
+      assert contains?(:janfu)
+
+      GenServer.stop(NodePool)
+    end
+
+    test "adds node name to pool only after given buffer time" do
+      # Start pool with buffer as 0.1 seconds
+      NodePool.start(100)
+
+      # Spawn node and assert still empty
+      send(NodePool, {:nodedown, :snafu})
+      assert empty?()
+
+      # Wait and check again
+      Process.sleep(100)
+      assert contains?(:snafu)
+
+      GenServer.stop(NodePool)
+    end
+  end
+
+  defp empty? do
+    state = :sys.get_state(NodePool)
+    Enum.empty?(state.pool)
+  end
+
+  defp contains?(atom) do
+    state = :sys.get_state(NodePool)
+    Enum.member?(state.pool, atom)
+  end
+end

--- a/test/livebook/runtime/node_pool_test.exs
+++ b/test/livebook/runtime/node_pool_test.exs
@@ -28,7 +28,7 @@ defmodule Livebook.Runtime.NodePoolTest do
       assert is_atom(result)
     end
 
-    test "adds a new node name to given pool when generated" do
+    test "adds a new node name to generated names when generated" do
       start_supervised!({NodePool, name: Baz})
 
       result = NodePool.get_name(Baz, node())

--- a/test/livebook/runtime/node_pool_test.exs
+++ b/test/livebook/runtime/node_pool_test.exs
@@ -32,19 +32,6 @@ defmodule Livebook.Runtime.NodePoolTest do
       assert is_atom(result)
     end
 
-    test "adds a new node name to generated names when generated" do
-      start_supervised!({NodePool, name: Baz, buffer_time: 1})
-
-      result = NodePool.get_name(Baz, node())
-
-      # Mock node down
-      send(Baz, {:nodedown, result, {}})
-      Process.sleep(2)
-
-      # Check if node name is added calling get_name/2 again
-      assert NodePool.get_name(Baz, node()) == result
-    end
-
     test "returns an existing name if pool is not empty" do
       start_supervised!({NodePool, name: Fu, buffer_time: 1})
 
@@ -68,19 +55,6 @@ defmodule Livebook.Runtime.NodePoolTest do
   end
 
   describe "On nodedown" do
-    test "adds node name to pool" do
-      start_supervised!({NodePool, name: Quux, buffer_time: 1})
-
-      name = NodePool.get_name(Quux, node())
-
-      # Mock a nodedown
-      send(Quux, {:nodedown, name, {}})
-      Process.sleep(2)
-
-      # Verify that name is in pool, by calling get_name/2
-      assert NodePool.get_name(Quux, node()) == name
-    end
-
     test "does not add node name to pool if not in generated_names" do
       start_supervised!({NodePool, name: Waldo})
 

--- a/test/livebook/runtime/node_pool_test.exs
+++ b/test/livebook/runtime/node_pool_test.exs
@@ -14,56 +14,56 @@ defmodule Livebook.Runtime.NodePoolTest do
   #    and the node is added to pool.
 
   describe "start_link" do
-    test "correctly starts a registered GenServer" do
-      start_supervised!({NodePool, name: Foo})
+    test "correctly starts a registered GenServer", config do
+      start_supervised!({NodePool, name: config.test})
 
       # Verify Process is running
-      assert Process.whereis(Foo)
+      assert Process.whereis(config.test)
     end
   end
 
   describe "get_name/2" do
-    test "creates a new node name if pool is empty" do
-      start_supervised!({NodePool, name: Bar})
+    test "creates a new node name if pool is empty", config do
+      start_supervised!({NodePool, name: config.test})
 
       # Assert that we get a result and that it is an atom
-      result = NodePool.get_name(Bar, node())
+      result = NodePool.get_name(config.test, node())
       assert result
       assert is_atom(result)
     end
 
-    test "returns an existing name if pool is not empty" do
-      start_supervised!({NodePool, name: Fu, buffer_time: 1})
+    test "returns an existing name if pool is not empty", config do
+      start_supervised!({NodePool, name: config.test, buffer_time: 1})
 
-      name = NodePool.get_name(Fu, node())
-      send(Fu, {:nodedown, name, {}})
+      name = NodePool.get_name(config.test, node())
+      send(config.test, {:nodedown, name, {}})
       Process.sleep(2)
 
-      assert NodePool.get_name(Fu, node()) == name
+      assert NodePool.get_name(config.test, node()) == name
     end
 
-    test "removes an existing name when used" do
-      start_supervised!({NodePool, name: Qux, buffer_time: 1})
+    test "removes an existing name when used", config do
+      start_supervised!({NodePool, name: config.test, buffer_time: 1})
 
-      name = NodePool.get_name(Qux, node())
-      send(Qux, {:nodedown, name, {}})
+      name = NodePool.get_name(config.test, node())
+      send(config.test, {:nodedown, name, {}})
       Process.sleep(2)
 
-      name = NodePool.get_name(Qux, node())
-      assert NodePool.get_name(Qux, node()) != name
+      name = NodePool.get_name(config.test, node())
+      assert NodePool.get_name(config.test, node()) != name
     end
   end
 
   describe "On nodedown" do
-    test "does not add node name to pool if not in generated_names" do
-      start_supervised!({NodePool, name: Waldo})
+    test "does not add node name to pool if not in generated_names", config do
+      start_supervised!({NodePool, name: config.test})
 
       # Mock a nodedown
-      send(Waldo, {:nodedown, :some_foo, {}})
+      send(config.test, {:nodedown, :some_foo, {}})
       Process.sleep(2)
 
       # Verify that name is not in pool, by calling get_name/2
-      assert NodePool.get_name(Waldo, node()) != :some_foo
+      assert NodePool.get_name(config.test, node()) != :some_foo
     end
   end
 end

--- a/test/livebook/runtime/node_pool_test.exs
+++ b/test/livebook/runtime/node_pool_test.exs
@@ -54,7 +54,7 @@ defmodule Livebook.Runtime.NodePoolTest do
     end
   end
 
-  describe "On nodedown" do
+  describe "on nodedown" do
     test "does not add node name to pool if not in generated_names", config do
       start_supervised!({NodePool, name: config.test})
 


### PR DESCRIPTION
Closes #202

Implements a node name pool that allows re-using of old node names, and generation of new names in the shortage of node names.

------

I have one question though:

Currently, the node pool uses state to store the names. Do you think we should use ETS instead ? (purely as an optimization technique)

Another thing I thought about after submitting this PR is using Poolboy (or something similar)

Also, I am not spawning actual nodes in my tests, as I found my node spawning code to be too slow/buggy.
Here is what I tried:

```elixir
defp spawn_node(node) do
    :slave.start(:net_adm.localhost(), node, inet_loader_args())
  end

  defp inet_loader_args do
    to_charlist("-loader inet -hosts 127.0.0.1 -setcookie  #{:erlang.get_cookie()}")
  end
```