### PR TITLE
Direct non-captured output to the terminal

### DIFF
--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -55,7 +55,10 @@ defmodule Livebook.Runtime.ElixirStandalone do
   defp start_elixir_node(elixir_path, node_name, eval, argv) do
     # Here we create a port to start the system process in a non-blocking way.
     Port.open({:spawn_executable, elixir_path}, [
-      :binary,
+      # We don't communicate with the system process via stdio,
+      # contrarily, we want any non-captured output to go directly
+      # to the terminal
+      :nouse_stdio,
       :hide,
       args: elixir_flags(node_name) ++ ["--eval", eval, "--" | Enum.map(argv, &to_string/1)]
     ])

--- a/lib/livebook/runtime/mix_standalone.ex
+++ b/lib/livebook/runtime/mix_standalone.ex
@@ -90,8 +90,10 @@ defmodule Livebook.Runtime.MixStandalone do
   defp start_elixir_mix_node(elixir_path, node_name, eval, argv, project_path) do
     # Here we create a port to start the system process in a non-blocking way.
     Port.open({:spawn_executable, elixir_path}, [
-      :binary,
-      :stderr_to_stdout,
+      # We don't communicate with the system process via stdio,
+      # contrarily, we want any non-captured output to go directly
+      # to the terminal
+      :nouse_stdio,
       :hide,
       cd: project_path,
       args:

--- a/lib/livebook/runtime/standalone_init.ex
+++ b/lib/livebook/runtime/standalone_init.ex
@@ -39,7 +39,9 @@ defmodule Livebook.Runtime.StandaloneInit do
       # Minimize schedulers busy wait threshold,
       # so that they go to sleep immediately after evaluation.
       # Enable ANSI escape codes as we handle them with HTML.
-      "+sbwt none +sbwtdcpu none +sbwtdio none -elixir ansi_enabled true",
+      # Disable stdin, so that the system process never tries to read
+      # any input from the terminal.
+      "+sbwt none +sbwtdcpu none +sbwtdio none -elixir ansi_enabled true -noinput",
       # Make the node hidden, so it doesn't automatically join the cluster
       "--hidden",
       # Use the cookie in Livebook


### PR DESCRIPTION
In #201 we stopped using the `:nouse_stdio` flag when opening the port, but consequently any output not captured by livebook, would go through the port and effectively be ignored. The rationale behind removing the flag was that it broke IEx (when running Livebook with `iex -S mix phx.server`). The reason behind this behavior is that `:nouse_stdio` links terminal input and output to the underlying system process, so the terminal input would be linked to both IEx shell and the standalone node. Adding `-noinput` erl switch to the node process fixes this, without suppressing the output :)