### PR TITLE
Fix jumping cursor when editing filename

### DIFF
--- a/assets/js/focus_on_update/index.js
+++ b/assets/js/focus_on_update/index.js
@@ -7,7 +7,9 @@ const FocusOnUpdate = {
   },
 
   updated() {
-    this.__focus();
+    if (this.el !== document.activeElement) {
+      this.__focus();
+    }
   },
 
   __focus() {


### PR DESCRIPTION
Fixes #281

Only focus the field if it's not already selected to avoid the cursor jumping as you update the text.