### PR TITLE
Make sure math equations are rendered sequentially

### DIFF
--- a/assets/js/cell/markdown.js
+++ b/assets/js/cell/markdown.js
@@ -79,18 +79,18 @@ class Markdown {
 
   // Replaces TeX formulas in string with rendered HTML using KaTeX.
   __renderMathInString(string) {
-    const options = {
-      throwOnError: false,
-      errorColor: "inherit",
-    };
+    return string.replace(
+      /(\${1,2})([\s\S]*?)\1/g,
+      (match, delimiter, math) => {
+        const displayMode = delimiter === "$$";
 
-    return string
-      .replace(/\$\$([\s\S]*?)\$\$/g, (match, math) => {
-        return katex.renderToString(math, { ...options, displayMode: true });
-      })
-      .replace(/\$([\s\S]*?)\$/g, (match, math) => {
-        return katex.renderToString(math, options);
-      });
+        return katex.renderToString(math.trim(), {
+          displayMode,
+          throwOnError: false,
+          errorColor: "inherit",
+        });
+      }
+    );
   }
 }
 


### PR DESCRIPTION
Closes #293.

Given a markdown text like:

```
$unclosed

$$
block
$$

$inline$
```

We currently render the display-style block (`$$block$$`) first:

```
$unclosed

{rendered html here}

$inline$
```

and then we look for the first inline pair, so we treat this whole text as an equation:

```
$unclosed

{rendered html here}

$
```

---

To solve this, I made the lookup sequential, so that we always match the first pair available, regardless if it's `$` or `$$`.