### PR TITLE
Ensure hostname is properly resolved when running in shortname distribution

### DIFF
--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -7,6 +7,7 @@ defmodule Livebook.Application do
 
   def start(_type, _args) do
     ensure_distribution!()
+    validate_hostname_resolution!()
     set_cookie()
 
     # We register our own :standard_error below
@@ -79,6 +80,22 @@ defmodule Livebook.Application do
 
         {:error, reason} ->
           Livebook.Config.abort!("could not start distributed node: #{inspect(reason)}")
+      end
+    end
+  end
+
+  # See https://github.com/elixir-nx/livebook/issues/302
+  defp validate_hostname_resolution!() do
+    unless Livebook.Config.longname() do
+      hostname = Livebook.Utils.node_host() |> to_charlist()
+
+      if :inet.gethostbyname(hostname) == {:error, :nxdomain} do
+        raise RuntimeError, """
+        your hostname "#{hostname}" does not resolve to any IP address, which indicates something wrong in your local configuration. \
+        Starting Livebook with long distribution name may help as a workaround:
+
+            livebook server --name livebook@127.0.0.1
+        """
       end
     end
   end


### PR DESCRIPTION
See #302 and https://github.com/elixir-nx/livebook/issues/275#issuecomment-845830230. There's probably not much we could do if hostname is not resolved to local IP, but validating this on startup should at least clarify this right away.