### PR TITLE
Delegate output formatting rules to Kino

### DIFF
--- a/lib/livebook/evaluator.ex
+++ b/lib/livebook/evaluator.ex
@@ -102,7 +102,7 @@ defmodule Livebook.Evaluator do
   def init(opts) do
     formatter = Keyword.get(opts, :formatter, Evaluator.IdentityFormatter)
 
-    {:ok, io_proxy} = Evaluator.IOProxy.start_link(formatter: formatter)
+    {:ok, io_proxy} = Evaluator.IOProxy.start_link()
 
     # Use the dedicated IO device as the group leader,
     # so that it handles all :stdio operations.

--- a/lib/livebook/evaluator/default_formatter.ex
+++ b/lib/livebook/evaluator/default_formatter.ex
@@ -30,7 +30,7 @@ defmodule Livebook.Evaluator.DefaultFormatter do
     {:error, formatted}
   end
 
-  @compile {:no_warn_undefined, {Kino.Render, :to_output, 1}}
+  @compile {:no_warn_undefined, {Kino.Render, :to_livebook, 1}}
 
   defp to_output(value) do
     # Kino is a "client side" extension for Livebook that may be
@@ -38,7 +38,7 @@ defmodule Livebook.Evaluator.DefaultFormatter do
     # its more precies output rendering rules.
     if Code.ensure_loaded?(Kino.Render) do
       try do
-        Kino.Render.to_output(value)
+        Kino.Render.to_livebook(value)
       catch
         kind, error ->
           {error, stacktrace} = Exception.blame(kind, error, __STACKTRACE__)

--- a/lib/livebook/evaluator/default_formatter.ex
+++ b/lib/livebook/evaluator/default_formatter.ex
@@ -29,15 +29,15 @@ defmodule Livebook.Evaluator.DefaultFormatter do
     {:error, formatted}
   end
 
-  @compile {:no_warn_undefined, {Kino.Transform, :to_livebook, 1}}
+  @compile {:no_warn_undefined, {Kino.Render, :to_output, 1}}
 
   defp value_to_output(value) do
     # Kino is a "client side" extension for Livebook that may be
     # installed into the runtime node. If it is installed we use
     # its more precies output rendering rules.
-    if Code.ensure_loaded?(Kino.Transform) do
+    if Code.ensure_loaded?(Kino.Render) do
       try do
-        Kino.Transform.to_livebook(value)
+        Kino.Render.to_output(value)
       catch
         kind, error ->
           {error, stacktrace} = Exception.blame(kind, error, __STACKTRACE__)

--- a/lib/livebook/evaluator/formatter.ex
+++ b/lib/livebook/evaluator/formatter.ex
@@ -17,11 +17,6 @@ defmodule Livebook.Evaluator.Formatter do
   alias Livebook.Evaluator
 
   @doc """
-  Transforms arbitrary evaluation output, usually binary.
-  """
-  @callback format_output(term()) :: term()
-
-  @doc """
   Transforms the evaluation response.
   """
   @callback format_response(Evaluator.evaluation_response()) :: term()

--- a/lib/livebook/evaluator/identity_formatter.ex
+++ b/lib/livebook/evaluator/identity_formatter.ex
@@ -6,8 +6,5 @@ defmodule Livebook.Evaluator.IdentityFormatter do
   @behaviour Livebook.Evaluator.Formatter
 
   @impl true
-  def format_output(output), do: output
-
-  @impl true
   def format_response(evaluation_response), do: evaluation_response
 end

--- a/lib/livebook/notebook/cell.ex
+++ b/lib/livebook/notebook/cell.ex
@@ -32,6 +32,9 @@ defmodule Livebook.Notebook.Cell do
           metadata: metadata()
         }
 
+  @typedoc """
+  For more details on output types see `t:Kino.Output.t/0`.
+  """
   @type output ::
           :ignored
           # Regular text, adjacent such outputs can be treated as a whole

--- a/lib/livebook/notebook/cell.ex
+++ b/lib/livebook/notebook/cell.ex
@@ -28,9 +28,22 @@ defmodule Livebook.Notebook.Cell do
           id: id(),
           type: type(),
           source: String.t(),
-          outputs: list(),
+          outputs: list(output()),
           metadata: metadata()
         }
+
+  @type output ::
+          :ignored
+          # Regular text, adjacent such outputs can be treated as a whole
+          | binary()
+          # Standalone text block
+          | {:text, binary()}
+          # Vega-Lite graphic
+          | {:vega_lite_static, spec :: map()}
+          # Vega-Lite graphic with dynamic data
+          | {:vega_lite_dynamic, widget_process :: pid()}
+          # Internal output format for errors
+          | {:error, message :: binary()}
 
   @doc """
   Returns an empty cell of the given type.

--- a/lib/livebook_web/live/output/vega_lite_dynamic_live.ex
+++ b/lib/livebook_web/live/output/vega_lite_dynamic_live.ex
@@ -1,4 +1,4 @@
-defmodule LivebookWeb.Kino.VegaLiteLive do
+defmodule LivebookWeb.Output.VegaLiteDynamicLive do
   use LivebookWeb, :live_view
 
   @impl true

--- a/lib/livebook_web/live/output/vega_lite_static_component.ex
+++ b/lib/livebook_web/live/output/vega_lite_static_component.ex
@@ -1,4 +1,4 @@
-defmodule LivebookWeb.SessionLive.VegaLiteComponent do
+defmodule LivebookWeb.Output.VegaLiteStaticComponent do
   use LivebookWeb, :live_component
 
   @impl true

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -235,53 +235,27 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     """
   end
 
-  defp render_output(_socket, output, id) when is_binary(output) do
+  defp render_output(_socket, text, id) when is_binary(text) do
+    text
     # Captured output usually has a trailing newline that we can ignore,
-    # because each line is itself a block anyway.
-    output = String.replace_suffix(output, "\n", "")
-    lines = ansi_to_html_lines(output)
-    assigns = %{lines: lines, id: id}
-
-    ~L"""
-    <div id="<%= @id %>" phx-hook="VirtualizedLines" data-max-height="300" data-follow="true">
-      <div data-template class="hidden"><%= for line <- @lines do %><div><%= line %></div><% end %></div>
-      <div data-content class="overflow-auto whitespace-pre text-gray-500 tiny-scrollbar"
-        id="<%= @id %>-content"
-        phx-update="ignore"></div>
-    </div>
-    """
+    # because each line is itself an HTML block anyway.
+    |> String.replace_suffix("\n", "")
+    |> render_virtualized_output(id, follow: true)
   end
 
-  defp render_output(_socket, {:inspect, inspected}, id) do
-    lines = ansi_to_html_lines(inspected)
-    assigns = %{lines: lines, id: id}
-
-    ~L"""
-    <div id="<%= @id %>" phx-hook="VirtualizedLines" data-max-height="300" data-follow="false">
-      <div data-template class="hidden"><%= for line <- @lines do %><div><%= line %></div><% end %></div>
-      <div data-content class="overflow-auto whitespace-pre text-gray-500 tiny-scrollbar"
-        id="<%= @id %>-content"
-        phx-update="ignore"></div>
-    </div>
-    """
+  defp render_output(_socket, {:text, text}, id) do
+    render_virtualized_output(text, id)
   end
 
-  defp render_output(socket, {:vega_lite_spec, spec}, id) do
+  defp render_output(socket, {:vega_lite_static, spec}, id) do
     live_component(socket, LivebookWeb.SessionLive.VegaLiteComponent, id: id, spec: spec)
   end
 
-  defp render_output(socket, {:kino_widget, :vega_lite, pid}, id) do
+  defp render_output(socket, {:vega_lite_dynamic, pid}, id) do
     live_render(socket, LivebookWeb.Kino.VegaLiteLive,
       id: id,
       session: %{"id" => id, "pid" => pid}
     )
-  end
-
-  defp render_output(_socket, {:kino_widget, type, _pid}, _id) do
-    render_error_message_output("""
-    Got unsupported Kino widget type: #{inspect(type)}, if that's a new widget
-    make usre to update Livebook to the latest version
-    """)
   end
 
   defp render_output(_socket, {:error, formatted}, _id) do
@@ -289,9 +263,32 @@ defmodule LivebookWeb.SessionLive.CellComponent do
   end
 
   defp render_output(_socket, output, _id) do
-    # Above we cover all possible outputs from DefaultFormatter,
-    # but this is helpful in development when adding new output types.
-    render_error_message_output("Unknown output type: #{inspect(output)}")
+    render_error_message_output("""
+    Unknown output format: #{inspect(output)}. If you're using Kino,
+    you may want to update Kino and Livebook to the latest version.
+    """)
+  end
+
+  defp render_virtualized_output(text, id, opts \\ []) do
+    follow = Keyword.get(opts, :follow, false)
+    lines = ansi_to_html_lines(text)
+    assigns = %{lines: lines, id: id, follow: follow}
+
+    ~L"""
+    <div id="<%= @id %>"
+      phx-hook="VirtualizedLines"
+      data-max-height="300"
+      data-follow="<%= follow %>">
+      <div data-template class="hidden">
+        <%= for line <- @lines do %>
+          <div><%= line %></div>
+        <% end %>
+      </div>
+      <div data-content class="overflow-auto whitespace-pre text-gray-500 tiny-scrollbar"
+        id="<%= @id %>-content"
+        phx-update="ignore"></div>
+    </div>
+    """
   end
 
   defp render_error_message_output(message) do

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -248,11 +248,11 @@ defmodule LivebookWeb.SessionLive.CellComponent do
   end
 
   defp render_output(socket, {:vega_lite_static, spec}, id) do
-    live_component(socket, LivebookWeb.SessionLive.VegaLiteComponent, id: id, spec: spec)
+    live_component(socket, LivebookWeb.Output.VegaLiteStaticComponent, id: id, spec: spec)
   end
 
   defp render_output(socket, {:vega_lite_dynamic, pid}, id) do
-    live_render(socket, LivebookWeb.Kino.VegaLiteLive,
+    live_render(socket, LivebookWeb.Output.VegaLiteDynamicLive,
       id: id,
       session: %{"id" => id, "pid" => pid}
     )

--- a/test/livebook/evaluator/io_proxy_test.exs
+++ b/test/livebook/evaluator/io_proxy_test.exs
@@ -52,11 +52,11 @@ defmodule Livebook.Evaluator.IOProxyTest do
     assert_received {:evaluation_output, :ref, "hey\n"}
   end
 
-  test "supports special livebook request type", %{io: io} do
+  test "supports direct livebook output forwarding", %{io: io} do
     ref = make_ref()
-    send(io, {:io_request, self(), ref, {:livebook_put_term, [1, 2, 3]}})
+    send(io, {:io_request, self(), ref, {:livebook_put_output, {:text, "[1, 2, 3]"}}})
     assert_receive {:io_reply, ^ref, :ok}
 
-    assert_received {:evaluation_output, :ref, [1, 2, 3]}
+    assert_received {:evaluation_output, :ref, {:text, "[1, 2, 3]"}}
   end
 end


### PR DESCRIPTION
In the context of output rendering there are two elements:
1. Converting an Elixir term to one of Livebook-recognised formats (plain text, inspect, Vega-Lite spec, ...)
2. Rendering the recognised formats (essentially the necessary html/js)

Point 2. is inherently Livebook related and needs to be a part of the app, but for point 1. that's not necessarily the case. Currently Livebook matches on the output, but we already had to do it for an external package (`VegaLite`) and adding support for other packages would require similar checks to be a part of Livebook itself.

To decouple point 1. from Livebook we decided to move the conversion rules to [`Kino`](https://github.com/elixir-nx/kino), where we define a protocol for anyone to implement.

So now Livebook inspects all results by default, and if `Kino` is installed its protocol is used to get more accurate output format (one of `Livebook.Notebook.Cell.output/0` type).

Also see https://github.com/elixir-nx/kino/pull/1.

![image](https://user-images.githubusercontent.com/17034772/120330969-9c490180-c2ed-11eb-8330-1d6d9fb20973.png)