### PR TITLE
Allow errors on boot to be reported

### DIFF
--- a/lib/livebook/application.ex
+++ b/lib/livebook/application.ex
@@ -10,9 +10,6 @@ defmodule Livebook.Application do
     validate_hostname_resolution!()
     set_cookie()
 
-    # We register our own :standard_error below
-    Process.unregister(:standard_error)
-
     children = [
       # Start the Telemetry supervisor
       LivebookWeb.Telemetry,

--- a/test/livebook/runtime/erl_dist/io_forward_gl_test.exs
+++ b/test/livebook/runtime/erl_dist/io_forward_gl_test.exs
@@ -4,7 +4,7 @@ defmodule Livebook.Runtime.ErlDist.IOForwardGLTest do
   alias Livebook.Runtime.ErlDist.IOForwardGL
 
   test "forwards requests to sender's group leader" do
-    {:ok, pid} = IOForwardGL.start_link()
+    pid = start_supervised!(IOForwardGL)
 
     group_leader_io =
       ExUnit.CaptureIO.capture_io(:stdio, fn ->


### PR DESCRIPTION
Because we unregistered standard_error, if there
was an error booting livebook, we would fail to
print the error. This commit makes sure the original
standard error is added back whenever the proxy
process terminates.

This could arise, for example, if you run `mix phx.server`
in one tab and then again in another, so the port is taken.