### PR TITLE
Support inputs

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -74,8 +74,16 @@
   @apply w-full px-3 py-2 bg-gray-50 text-sm border border-gray-200 rounded-lg placeholder-gray-400 text-gray-600;
 }
 
+.input--error {
+  @apply bg-red-50 border-red-600 text-red-600;
+}
+
 .input-label {
   @apply mb-0.5 text-sm text-gray-800 font-medium;
+}
+
+.input-error {
+  @apply mt-2 text-red-600 italic text-xs;
 }
 
 .switch-button {

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -99,6 +99,21 @@
   @apply bg-blue-600;
 }
 
+.radio-base {
+  appearance: none;
+  width: 20px;
+  height: 20px;
+  cursor: pointer;
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='10' cy='10' r='9.5' stroke='%23CAD5E0' fill='white' /%3e%3c/svg%3e");
+  background-size: 100% 100%;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.radio-base:checked {
+  background-image: url("data:image/svg+xml,%3csvg viewBox='0 0 20 20' xmlns='http://www.w3.org/2000/svg'%3e%3ccircle cx='10' cy='10' r='9.5' stroke='%233E64FF' fill='white' /%3e%3ccircle cx='10' cy='10' r='6' fill='%233E64FF' /%3e%3c/svg%3e");
+}
+
 /* Custom scrollbars */
 
 .tiny-scrollbar::-webkit-scrollbar {

--- a/assets/js/cell/index.js
+++ b/assets/js/cell/index.js
@@ -4,7 +4,6 @@ import Markdown from "./markdown";
 import { globalPubSub } from "../lib/pub_sub";
 import { smoothlyScrollToElement } from "../lib/utils";
 import scrollIntoView from "scroll-into-view-if-needed";
-import monaco from "./live_editor/monaco";
 
 /**
  * A hook managing a single cell.

--- a/assets/js/cell/index.js
+++ b/assets/js/cell/index.js
@@ -207,6 +207,10 @@ function handleCellMoved(hook, cellId) {
 }
 
 function handleCellUpload(hook, cellId, url) {
+  if (!hook.state.liveEditor) {
+    return;
+  }
+
   if (hook.props.cellId === cellId) {
     const markdown = `![](${url})`;
     hook.state.liveEditor.insert(markdown);
@@ -214,6 +218,10 @@ function handleCellUpload(hook, cellId, url) {
 }
 
 function handleLocationReport(hook, client, report) {
+  if (!hook.state.liveEditor) {
+    return;
+  }
+
   if (hook.props.cellId === report.cellId && report.selection) {
     hook.state.liveEditor.updateUserSelection(client, report.selection);
   } else {

--- a/assets/js/focus_on_update/index.js
+++ b/assets/js/focus_on_update/index.js
@@ -1,3 +1,5 @@
+import { isEditableElement } from "../lib/utils";
+
 /**
  * A hook used to focus an element whenever it receives LV update.
  */
@@ -13,6 +15,10 @@ const FocusOnUpdate = {
   },
 
   __focus() {
+    if (isEditableElement(document.activeElement)) {
+      return;
+    }
+
     this.el.focus();
     this.el.selectionStart = this.el.selectionEnd = this.el.value.length;
   },

--- a/assets/js/morphdom_callbacks.js
+++ b/assets/js/morphdom_callbacks.js
@@ -8,6 +8,18 @@ const callbacks = {
       }
     }
   },
+
+  onNodeAdded(node) {
+    // Mimic autofocus for dynamically inserted elements
+    if (node.nodeType === Node.ELEMENT_NODE && node.hasAttribute("autofocus")) {
+      node.focus();
+
+      if (node.setSelectionRange && node.value) {
+        const lastIndex = node.value.length;
+        node.setSelectionRange(lastIndex, lastIndex);
+      }
+    }
+  },
 };
 
 export default callbacks;

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -687,7 +687,9 @@ function setInsertMode(hook, insertModeEnabled) {
 
 function handleCellInserted(hook, cellId) {
   setFocusedCell(hook, cellId);
-  setInsertMode(hook, true);
+  if (["markdown", "elixir"].includes(hook.state.focusedCellType)) {
+    setInsertMode(hook, true);
+  }
 }
 
 function handleCellDeleted(hook, cellId, siblingCellId) {

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -351,7 +351,10 @@ function handleDocumentMouseDown(hook, event) {
     const editorContainer = cell.querySelector(
       `[data-element="editor-container"]`
     );
-    const editorClicked = !!editorContainer && editorContainer.contains(event.target);
+    const input = cell.querySelector(`[data-element="input"]`);
+    const editableElement = editorContainer || input;
+
+    const editorClicked = editableElement.contains(event.target);
     const insertMode = editorClicked;
     if (hook.state.insertMode !== insertMode) {
       setInsertMode(hook, insertMode);

--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -351,7 +351,7 @@ function handleDocumentMouseDown(hook, event) {
     const editorContainer = cell.querySelector(
       `[data-element="editor-container"]`
     );
-    const editorClicked = editorContainer.contains(event.target);
+    const editorClicked = !!editorContainer && editorContainer.contains(event.target);
     const insertMode = editorClicked;
     if (hook.state.insertMode !== insertMode) {
       setInsertMode(hook, insertMode);

--- a/lib/livebook/evaluator.ex
+++ b/lib/livebook/evaluator.ex
@@ -144,6 +144,7 @@ defmodule Livebook.Evaluator do
       end
 
     Evaluator.IOProxy.flush(state.io_proxy)
+    Evaluator.IOProxy.clear_input_buffers(state.io_proxy)
 
     send_evaluation_response(send_to, ref, response, state.formatter)
 

--- a/lib/livebook/evaluator/io_proxy.ex
+++ b/lib/livebook/evaluator/io_proxy.ex
@@ -196,11 +196,11 @@ defmodule Livebook.Evaluator.IOProxy do
     receive do
       {:evaluation_input_reply, {:ok, string}} ->
         string = :unicode.characters_to_binary(string, state.encoding, encoding)
-        Process.demonitor(ref)
+        Process.demonitor(ref, [:flush])
         {string, state}
 
       {:evaluation_input_reply, :error} ->
-        Process.demonitor(ref)
+        Process.demonitor(ref, [:flush])
         {:eof, state}
 
       {:DOWN, ^ref, :process, _object, _reason} ->

--- a/lib/livebook/evaluator/io_proxy.ex
+++ b/lib/livebook/evaluator/io_proxy.ex
@@ -201,7 +201,7 @@ defmodule Livebook.Evaluator.IOProxy do
 
       {:evaluation_input_reply, :error} ->
         Process.demonitor(ref, [:flush])
-        {:eof, state}
+        {{:error, "no matching Livebook input found"}, state}
 
       {:DOWN, ^ref, :process, _object, _reason} ->
         {{:error, :terminated}, state}

--- a/lib/livebook/live_markdown.ex
+++ b/lib/livebook/live_markdown.ex
@@ -5,20 +5,31 @@ defmodule Livebook.LiveMarkdown do
   #
   # The format is based off of Markdown and preserves compatibility,
   # in the sense that every LiveMarkdown file is a valid Markdown file.
-  # LiveMarkdown uses HTML comments for storing metadata, so a Markdown standard
-  # supporting such comments is assumed. Not every Markdown file is a valid LiveMarkdown file,
-  # but may be converted to such by applying tiny changes, which the import function does.
+  # LiveMarkdown uses HTML comments for storing metadata, so a Markdown
+  # standard supporting such comments is assumed. Not every Markdown file
+  # is a valid LiveMarkdown file, but may be converted to such by applying
+  # tiny changes, which the import function does.
   #
   # Currently the format is straightforward and specifies the following:
   #
-  # 1. The file should have a leading *Heading 1* holding the notebook name.
-  # 2. Every *Heading 2* starts a new section.
-  # 3. Every Elixir code block maps to an Elixir cell.
-  # 4. Adjacent regular Markdown text maps to a Markdown cell.
-  # 5. Comments of the form `<!-- livebook:json_object -->` hold metadata
-  #    and apply to the element they directly precede (e.g. an Elixir cell).
-  #    Such comments may appear anywhere, for instance `<!-- livebook:{"force_markdown":true} -->`
-  #    forces the next Markdown block to be treated as part of Markdown cell (even if it's Elixir code block).
+  #   1. The file should have a leading *Heading 1* holding the notebook name
+  #
+  #   2. Every *Heading 2* starts a new section
+  #
+  #   3. Every Elixir code block maps to an Elixir cell
+  #
+  #   4. Adjacent regular Markdown text maps to a Markdown cell
+  #
+  #   5. Comments of the form `<!-- livebook:json_object -->` hold Livebook data
+  #      and may be one of the following:
+  #
+  #      * a description of a notebook object that cannot be naturally encoded
+  #        using Markdown, in such case the JSON contains a "livebook_object" field
+  #
+  #      * a metadata that may appear anywhere and applies to the element
+  #        it directly precedes, for instance `<!-- livebook:{"force_markdown":true} -->`
+  #        forces the next Markdown block to be treated as part of Markdown cell
+  #        (even if it's Elixir code block)
   #
   # ## Example
   #

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -49,15 +49,15 @@ defmodule Livebook.LiveMarkdown.Export do
   end
 
   defp render_cell(%Cell.Input{} = cell) do
-    input_cell_json =
+    json =
       Jason.encode!(%{
+        livebook_object: :cell_input,
         type: cell.type,
         name: cell.name,
         value: cell.value
       })
 
-    # TODO: alternatively ew can store "object": "cell_input" in the json, just need more clever parsing in import then
-    "<!-- livebook:object:cell_input:#{input_cell_json} -->"
+    "<!-- livebook:#{json} -->"
     |> prepend_metadata(cell.metadata)
   end
 

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -48,6 +48,19 @@ defmodule Livebook.LiveMarkdown.Export do
     |> prepend_metadata(cell.metadata)
   end
 
+  defp render_cell(%Cell.Input{} = cell) do
+    input_cell_json =
+      Jason.encode!(%{
+        type: cell.type,
+        name: cell.name,
+        value: cell.value
+      })
+
+    # TODO: alternatively ew can store "object": "cell_input" in the json, just need more clever parsing in import then
+    "<!-- livebook:object:cell_input:#{input_cell_json} -->"
+    |> prepend_metadata(cell.metadata)
+  end
+
   defp get_elixir_cell_code(%{source: source, metadata: %{"disable_formatting" => true}}),
     do: source
 

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -1,5 +1,6 @@
 defmodule Livebook.LiveMarkdown.Export do
   alias Livebook.Notebook
+  alias Livebook.Notebook.Cell
   alias Livebook.LiveMarkdown.MarkdownHelpers
 
   @doc """
@@ -30,13 +31,13 @@ defmodule Livebook.LiveMarkdown.Export do
     |> prepend_metadata(section.metadata)
   end
 
-  defp render_cell(%{type: :markdown} = cell) do
+  defp render_cell(%Cell.Markdown{} = cell) do
     cell.source
     |> format_markdown_source()
     |> prepend_metadata(cell.metadata)
   end
 
-  defp render_cell(%{type: :elixir} = cell) do
+  defp render_cell(%Cell.Elixir{} = cell) do
     code = get_elixir_cell_code(cell)
 
     """

--- a/lib/livebook/notebook.ex
+++ b/lib/livebook/notebook.ex
@@ -236,40 +236,73 @@ defmodule Livebook.Notebook do
   end
 
   @doc """
-  Returns a list of `{cell, section}` pairs including all Elixir cells in order.
+  Returns a list of `{cell, section}` pairs including all cells.
   """
-  @spec elixir_cells_with_section(t()) :: list({Cell.t(), Section.t()})
-  def elixir_cells_with_section(notebook) do
+  @spec cells_with_section(t()) :: list({Cell.t(), Section.t()})
+  def cells_with_section(notebook) do
     for section <- notebook.sections,
         cell <- section.cells,
-        is_struct(cell, Cell.Elixir),
         do: {cell, section}
   end
 
   @doc """
-  Returns a list of Elixir cells (each with section) that the given cell depends on.
+  Returns a list of `{cell, section}` pairs including all Elixir cells in order.
+  """
+  @spec elixir_cells_with_section(t()) :: list({Cell.t(), Section.t()})
+  def elixir_cells_with_section(notebook) do
+    notebook
+    |> cells_with_section()
+    |> Enum.filter(fn {cell, _section} -> is_struct(cell, Cell.Elixir) end)
+  end
+
+  @doc """
+  Returns a list of cells (each with section) that go logically
+  before the given one.
 
   The cells are ordered starting from the most direct parent.
   """
   @spec parent_cells_with_section(t(), Cell.id()) :: list({Cell.t(), Section.t()})
   def parent_cells_with_section(notebook, cell_id) do
     notebook
-    |> elixir_cells_with_section()
+    |> cells_with_section()
     |> Enum.take_while(fn {cell, _} -> cell.id != cell_id end)
     |> Enum.reverse()
   end
 
   @doc """
-  Returns a list of Elixir cells (each with section) that depend on the given cell.
+  Returns a list of cells (each with section) that go logically
+  after the given one, and thus may depend on it.
 
   The cells are ordered starting from the most direct child.
   """
   @spec child_cells_with_section(t(), Cell.id()) :: list({Cell.t(), Section.t()})
   def child_cells_with_section(notebook, cell_id) do
     notebook
-    |> elixir_cells_with_section()
+    |> cells_with_section()
     |> Enum.drop_while(fn {cell, _} -> cell.id != cell_id end)
     |> Enum.drop(1)
+  end
+
+  @doc """
+  Finds an input cell available to the given cell and matching
+  the given prompt.
+  """
+  @spec input_cell_for_prompt(t(), Cell.id(), String.t()) :: {:ok, Cell.Input.t()} | :error
+  def input_cell_for_prompt(notebook, cell_id, prompt) do
+    notebook
+    |> parent_cells_with_section(cell_id)
+    |> Enum.map(fn {cell, _} -> cell end)
+    |> Enum.filter(fn cell ->
+      is_struct(cell, Cell.Input) and String.starts_with?(prompt, cell.name)
+    end)
+    |> case do
+      [] ->
+        :error
+
+      input_cells ->
+        cell = Enum.max_by(input_cells, &String.length(&1.name))
+        {:ok, cell}
+    end
   end
 
   @doc """

--- a/lib/livebook/notebook.ex
+++ b/lib/livebook/notebook.ex
@@ -242,7 +242,7 @@ defmodule Livebook.Notebook do
   def elixir_cells_with_section(notebook) do
     for section <- notebook.sections,
         cell <- section.cells,
-        cell.type == :elixir,
+        is_struct(cell, Cell.Elixir),
         do: {cell, section}
   end
 

--- a/lib/livebook/notebook/cell.ex
+++ b/lib/livebook/notebook/cell.ex
@@ -4,15 +4,13 @@ defmodule Livebook.Notebook.Cell do
   # Data structure representing a single cell in a notebook.
   #
   # A cell is the smallest unit of work in a notebook.
-  # It primarily consists of text content that the user can edit
-  # and may potentially produce some output (e.g. during code evaluation).
-
-  defstruct [:id, :type, :source, :outputs, :metadata]
+  # It may consist of text content, outputs, rendered content
+  # and other special forms.
 
   alias Livebook.Utils
+  alias Livebook.Notebook.Cell
 
   @type id :: Utils.id()
-  @type type :: :markdown | :elixir | :input
 
   @typedoc """
   Arbitrary cell information persisted as part of the notebook.
@@ -24,41 +22,15 @@ defmodule Livebook.Notebook.Cell do
   """
   @type metadata :: %{String.t() => term()}
 
-  @type t :: %__MODULE__{
-          id: id(),
-          type: type(),
-          source: String.t(),
-          outputs: list(output()),
-          metadata: metadata()
-        }
-
-  @typedoc """
-  For more details on output types see `t:Kino.Output.t/0`.
-  """
-  @type output ::
-          :ignored
-          # Regular text, adjacent such outputs can be treated as a whole
-          | binary()
-          # Standalone text block
-          | {:text, binary()}
-          # Vega-Lite graphic
-          | {:vega_lite_static, spec :: map()}
-          # Vega-Lite graphic with dynamic data
-          | {:vega_lite_dynamic, widget_process :: pid()}
-          # Internal output format for errors
-          | {:error, message :: binary()}
+  @type t :: Cell.Elixir.t() | Cell.Markdown.t() | Cell.Input.t()
 
   @doc """
   Returns an empty cell of the given type.
   """
-  @spec new(type()) :: t()
-  def new(type) do
-    %__MODULE__{
-      id: Utils.random_id(),
-      type: type,
-      source: "",
-      outputs: [],
-      metadata: %{}
-    }
-  end
+  @spec new(:markdown | :elixir | :input) :: t()
+  def new(type)
+
+  def new(:markdown), do: Cell.Markdown.new()
+  def new(:elixir), do: Cell.Elixir.new()
+  def new(:input), do: Cell.Input.new()
 end

--- a/lib/livebook/notebook/cell.ex
+++ b/lib/livebook/notebook/cell.ex
@@ -12,7 +12,7 @@ defmodule Livebook.Notebook.Cell do
   alias Livebook.Utils
 
   @type id :: Utils.id()
-  @type type :: :markdown | :elixir
+  @type type :: :markdown | :elixir | :input
 
   @typedoc """
   Arbitrary cell information persisted as part of the notebook.

--- a/lib/livebook/notebook/cell/elixir.ex
+++ b/lib/livebook/notebook/cell/elixir.ex
@@ -1,0 +1,49 @@
+defmodule Livebook.Notebook.Cell.Elixir do
+  @moduledoc false
+
+  # A cell with Elixir code.
+  #
+  # It consists of text content that the user can edit
+  # and produces some output once evaluated.
+
+  defstruct [:id, :metadata, :source, :outputs]
+
+  alias Livebook.Utils
+  alias Livebook.Notebook.Cell
+
+  @type t :: %__MODULE__{
+          id: Cell.id(),
+          metadata: Cell.metadata(),
+          source: String.t(),
+          outputs: list(output())
+        }
+
+  @typedoc """
+  For more details on output types see `t:Kino.Output.t/0`.
+  """
+  @type output ::
+          :ignored
+          # Regular text, adjacent such outputs can be treated as a whole
+          | binary()
+          # Standalone text block
+          | {:text, binary()}
+          # Vega-Lite graphic
+          | {:vega_lite_static, spec :: map()}
+          # Vega-Lite graphic with dynamic data
+          | {:vega_lite_dynamic, widget_process :: pid()}
+          # Internal output format for errors
+          | {:error, message :: binary()}
+
+  @doc """
+  Returns an empty cell.
+  """
+  @spec new() :: t()
+  def new() do
+    %__MODULE__{
+      id: Utils.random_id(),
+      metadata: %{},
+      source: "",
+      outputs: []
+    }
+  end
+end

--- a/lib/livebook/notebook/cell/input.ex
+++ b/lib/livebook/notebook/cell/input.ex
@@ -19,7 +19,7 @@ defmodule Livebook.Notebook.Cell.Input do
           value: String.t()
         }
 
-  @type type :: :text
+  @type type :: :text | :url
 
   @doc """
   Returns an empty cell.

--- a/lib/livebook/notebook/cell/input.ex
+++ b/lib/livebook/notebook/cell/input.ex
@@ -30,8 +30,7 @@ defmodule Livebook.Notebook.Cell.Input do
       id: Utils.random_id(),
       metadata: %{},
       type: :text,
-      # TODO: better default?
-      name: "Input",
+      name: "input",
       value: ""
     }
   end

--- a/lib/livebook/notebook/cell/input.ex
+++ b/lib/livebook/notebook/cell/input.ex
@@ -6,7 +6,7 @@ defmodule Livebook.Notebook.Cell.Input do
   # It consists of an input that the user may fill
   # and then read during code evaluation.
 
-  defstruct [:id, :metadata, :type, :value]
+  defstruct [:id, :metadata, :type, :name, :value]
 
   alias Livebook.Utils
   alias Livebook.Notebook.Cell
@@ -15,6 +15,7 @@ defmodule Livebook.Notebook.Cell.Input do
           id: Cell.id(),
           metadata: Cell.metadata(),
           type: type(),
+          name: String.t(),
           value: String.t()
         }
 
@@ -29,6 +30,8 @@ defmodule Livebook.Notebook.Cell.Input do
       id: Utils.random_id(),
       metadata: %{},
       type: :text,
+      # TODO: better default?
+      name: "Input",
       value: ""
     }
   end

--- a/lib/livebook/notebook/cell/input.ex
+++ b/lib/livebook/notebook/cell/input.ex
@@ -34,4 +34,23 @@ defmodule Livebook.Notebook.Cell.Input do
       value: ""
     }
   end
+
+  @doc """
+  Checks if the input cell contains a valid value
+  for its type.
+  """
+  @spec validate(t()) :: :ok | {:error, String.t()}
+  def validate(cell) do
+    validate_value(cell.value, cell.type)
+  end
+
+  defp validate_value(_value, :text), do: :ok
+
+  defp validate_value(value, :url) do
+    if Utils.valid_url?(value) do
+      :ok
+    else
+      {:error, "not a valid URL"}
+    end
+  end
 end

--- a/lib/livebook/notebook/cell/input.ex
+++ b/lib/livebook/notebook/cell/input.ex
@@ -1,0 +1,35 @@
+defmodule Livebook.Notebook.Cell.Input do
+  @moduledoc false
+
+  # A cell with an input field.
+  #
+  # It consists of an input that the user may fill
+  # and then read during code evaluation.
+
+  defstruct [:id, :metadata, :type, :value]
+
+  alias Livebook.Utils
+  alias Livebook.Notebook.Cell
+
+  @type t :: %__MODULE__{
+          id: Cell.id(),
+          metadata: Cell.metadata(),
+          type: type(),
+          value: String.t()
+        }
+
+  @type type :: :text
+
+  @doc """
+  Returns an empty cell.
+  """
+  @spec new() :: t()
+  def new() do
+    %__MODULE__{
+      id: Utils.random_id(),
+      metadata: %{},
+      type: :text,
+      value: ""
+    }
+  end
+end

--- a/lib/livebook/notebook/cell/markdown.ex
+++ b/lib/livebook/notebook/cell/markdown.ex
@@ -1,0 +1,31 @@
+defmodule Livebook.Notebook.Cell.Markdown do
+  @moduledoc false
+
+  # A cell with Markdown text content.
+  #
+  # It consists of Markdown content that the user can edit
+  # and which is then rendered on the page.
+
+  defstruct [:id, :metadata, :source]
+
+  alias Livebook.Utils
+  alias Livebook.Notebook.Cell
+
+  @type t :: %__MODULE__{
+          id: Cell.id(),
+          metadata: Cell.metadata(),
+          source: String.t()
+        }
+
+  @doc """
+  Returns an empty cell.
+  """
+  @spec new() :: t()
+  def new() do
+    %__MODULE__{
+      id: Utils.random_id(),
+      metadata: %{},
+      source: ""
+    }
+  end
+end

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -52,16 +52,20 @@ defprotocol Livebook.Runtime do
   Evaluation outputs are send to the connected runtime owner.
   The messages should be of the form:
 
-  * `{:evaluation_output, ref, output}` - output captured during evaluation
-  * `{:evaluation_response, ref, output}` - final result of the evaluation
+    * `{:evaluation_output, ref, output}` - output captured during evaluation
+    * `{:evaluation_response, ref, output}` - final result of the evaluation
+
+  The evaluation may request user input by sending `{:evaluation_input, ref, reply_to, prompt}`
+  to the runtime owner, who is supposed to reply with `{:evaluation_input_reply, reply}`
+  with `reply` being either `{:ok, input}` or `:error` if no matching input can be found.
 
   If the evaluation state within a container is lost (e.g. a process goes down),
   the runtime can send `{:container_down, container_ref, message}` to notify the owner.
 
   ## Options
 
-  * `:file` - file to which the evaluated code belongs. Most importantly,
-    this has an impact on the value of `__DIR__`.
+    * `:file` - file to which the evaluated code belongs. Most importantly,
+      this has an impact on the value of `__DIR__`.
   """
   @spec evaluate_code(t(), String.t(), ref(), ref(), ref() | nil, keyword()) :: :ok
   def evaluate_code(runtime, code, container_ref, evaluation_ref, prev_evaluation_ref, opts \\ [])

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -204,6 +204,14 @@ defmodule Livebook.Session do
   end
 
   @doc """
+  Asynchronously sends a cell value update to the server.
+  """
+  @spec set_cell_value(id(), Cell.id(), String.t()) :: :ok
+  def set_cell_value(session_id, cell_id, value) do
+    GenServer.cast(name(session_id), {:set_cell_value, self(), cell_id, value})
+  end
+
+  @doc """
   Asynchronously sends a cell metadata update to the server.
   """
   @spec set_cell_metadata(id(), Cell.id(), Cell.metadata()) :: :ok
@@ -405,6 +413,11 @@ defmodule Livebook.Session do
 
   def handle_cast({:report_cell_revision, client_pid, cell_id, revision}, state) do
     operation = {:report_cell_revision, client_pid, cell_id, revision}
+    {:noreply, handle_operation(state, operation)}
+  end
+
+  def handle_cast({:set_cell_value, client_pid, cell_id, value}, state) do
+    operation = {:set_cell_value, client_pid, cell_id, value}
     {:noreply, handle_operation(state, operation)}
   end
 

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -204,22 +204,6 @@ defmodule Livebook.Session do
   end
 
   @doc """
-  Asynchronously sends a cell value update to the server.
-  """
-  @spec set_cell_value(id(), Cell.id(), String.t()) :: :ok
-  def set_cell_value(session_id, cell_id, value) do
-    GenServer.cast(name(session_id), {:set_cell_value, self(), cell_id, value})
-  end
-
-  @doc """
-  Asynchronously sends a cell metadata update to the server.
-  """
-  @spec set_cell_metadata(id(), Cell.id(), Cell.metadata()) :: :ok
-  def set_cell_metadata(session_id, cell_id, metadata) do
-    GenServer.cast(name(session_id), {:set_cell_metadata, self(), cell_id, metadata})
-  end
-
-  @doc """
   Asynchronously sends a cell attributes update to the server.
   """
   @spec set_cell_attributes(id(), Cell.id(), map()) :: :ok
@@ -421,16 +405,6 @@ defmodule Livebook.Session do
 
   def handle_cast({:report_cell_revision, client_pid, cell_id, revision}, state) do
     operation = {:report_cell_revision, client_pid, cell_id, revision}
-    {:noreply, handle_operation(state, operation)}
-  end
-
-  def handle_cast({:set_cell_value, client_pid, cell_id, value}, state) do
-    operation = {:set_cell_value, client_pid, cell_id, value}
-    {:noreply, handle_operation(state, operation)}
-  end
-
-  def handle_cast({:set_cell_metadata, client_pid, cell_id, metadata}, state) do
-    operation = {:set_cell_metadata, client_pid, cell_id, metadata}
     {:noreply, handle_operation(state, operation)}
   end
 

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -496,8 +496,11 @@ defmodule Livebook.Session do
 
   def handle_info({:evaluation_input, cell_id, reply_to, prompt}, state) do
     reply =
-      with {:ok, cell} <- Notebook.input_cell_for_prompt(state.data.notebook, cell_id, prompt) do
+      with {:ok, cell} <- Notebook.input_cell_for_prompt(state.data.notebook, cell_id, prompt),
+           :ok <- Cell.Input.validate(cell) do
         {:ok, cell.value <> "\n"}
+      else
+        _ -> :error
       end
 
     send(reply_to, {:evaluation_input_reply, reply})

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -252,7 +252,7 @@ defmodule Livebook.Session.Data do
 
   def apply_operation(data, {:queue_cell_evaluation, _client_pid, id}) do
     with {:ok, cell, section} <- Notebook.fetch_cell_and_section(data.notebook, id),
-         :elixir <- cell.type,
+         %Cell.Elixir{} <- cell,
          :ready <- data.cell_infos[cell.id].evaluation_status do
       data
       |> with_actions()
@@ -591,7 +591,7 @@ defmodule Livebook.Session.Data do
       cells_with_section
       |> Enum.map(fn {cell, _section} -> cell end)
       |> Enum.filter(fn cell ->
-        cell.type == :elixir and data.cell_infos[cell.id].validity_status == :evaluated
+        is_struct(cell, Cell.Elixir) and data.cell_infos[cell.id].validity_status == :evaluated
       end)
 
     data_actions
@@ -822,7 +822,9 @@ defmodule Livebook.Session.Data do
       revision_by_client_pid: Map.new(client_pids, &{&1, 0}),
       validity_status: :fresh,
       evaluation_status: :ready,
-      digest: compute_digest(cell.source),
+      # TODO: handle properly
+      # digest: compute_digest(cell.source),
+      digest: compute_digest(Map.get(cell, :source, "")),
       evaluation_digest: nil
     }
   end

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -414,7 +414,7 @@ defmodule Livebook.Session.Data do
       data
       |> with_actions()
       |> set_cell_attributes(cell, attrs)
-      |> tap(fn data_actions ->
+      |> then(fn data_actions ->
         if invalidates_dependent do
           mark_dependent_cells_as_stale(data_actions, cell)
         else

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -410,6 +410,8 @@ defmodule Livebook.Session.Data do
       |> with_actions()
       |> set_cell_value(cell, value)
       # TODO: think about it, but most likely just that:
+      # TODO: note that ucrrently cell must be elixir for this to work so fix it
+      #       together with the other fix in session.ex
       # |> mark_dependent_cells_as_stale(cell)
       |> set_dirty()
       |> wrap_ok()

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -106,4 +106,13 @@ defmodule Livebook.Utils do
         raise "Livebook.Utils.access_by_id/1 expected a list, got: #{inspect(data)}"
     end
   end
+
+  @doc """
+  Validates if the given URL is syntactically valid.
+  """
+  @spec valid_url?(String.t()) :: boolean()
+  def valid_url?(url) do
+    uri = URI.parse(url)
+    uri.scheme != nil and uri.host != nil and uri.host =~ "."
+  end
 end

--- a/lib/livebook_web/helpers.ex
+++ b/lib/livebook_web/helpers.ex
@@ -114,4 +114,20 @@ defmodule LivebookWeb.Helpers do
     |> String.downcase()
     |> String.replace(~r/\s+/u, "-")
   end
+
+  @doc """
+  Renders a lits of radio input options with the given one selected.
+  """
+  def render_radios(name, options, selected) do
+    assigns = %{name: name, options: options, selected: selected}
+
+    ~L"""
+    <%= for {value, label} <- options do %>
+      <label class="flex space-x-2 items-center cursor-pointer">
+        <%= tag :input, type: "radio", class: "radio-base", name: @name, value: value, checked: value == selected %>
+        <div class="text-medium text-gray-700"><%= label %></div>
+      </label>
+    <% end %>
+    """
+  end
 end

--- a/lib/livebook_web/live/home_live/import_url_component.ex
+++ b/lib/livebook_web/live/home_live/import_url_component.ex
@@ -1,7 +1,7 @@
 defmodule LivebookWeb.HomeLive.ImportUrlComponent do
   use LivebookWeb, :live_component
 
-  alias Livebook.ContentLoader
+  alias Livebook.{ContentLoader, Utils}
 
   @impl true
   def mount(socket) do
@@ -31,7 +31,7 @@ defmodule LivebookWeb.HomeLive.ImportUrlComponent do
               spellcheck: "false" %>
         <%= submit "Import",
               class: "mt-5 button button-blue",
-              disabled: not valid_url?(@url) %>
+              disabled: not Utils.valid_url?(@url) %>
       </form>
     </div>
     """
@@ -54,10 +54,5 @@ defmodule LivebookWeb.HomeLive.ImportUrlComponent do
       {:error, message} ->
         {:noreply, assign(socket, error_message: String.capitalize(message))}
     end
-  end
-
-  defp valid_url?(url) do
-    uri = URI.parse(url)
-    uri.scheme != nil and uri.host != nil and uri.host =~ "."
   end
 end

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -290,8 +290,11 @@ defmodule LivebookWeb.SessionLive do
     """
   end
 
-  defp settings_component_for(%Cell.Elixir{}), do: LivebookWeb.SessionLive.ElixirCellSettingsComponent
-  defp settings_component_for(%Cell.Input{}), do: LivebookWeb.SessionLive.InputCellSettingsComponent
+  defp settings_component_for(%Cell.Elixir{}),
+    do: LivebookWeb.SessionLive.ElixirCellSettingsComponent
+
+  defp settings_component_for(%Cell.Input{}),
+    do: LivebookWeb.SessionLive.InputCellSettingsComponent
 
   @impl true
   def handle_params(%{"cell_id" => cell_id}, _url, socket) do
@@ -422,7 +425,7 @@ defmodule LivebookWeb.SessionLive do
   end
 
   def handle_event("set_cell_value", %{"cell_id" => cell_id, "value" => value}, socket) do
-    Session.set_cell_value(socket.assigns.session_id, cell_id, value)
+    Session.set_cell_attributes(socket.assigns.session_id, cell_id, %{value: value})
 
     {:noreply, socket}
   end

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -823,6 +823,7 @@ defmodule LivebookWeb.SessionLive do
       id: cell.id,
       type: :input,
       input_type: cell.type,
+      name: cell.name,
       value: cell.value
     }
   end

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -839,7 +839,12 @@ defmodule LivebookWeb.SessionLive do
       type: :input,
       input_type: cell.type,
       name: cell.name,
-      value: cell.value
+      value: cell.value,
+      error:
+        case Cell.Input.validate(cell) do
+          :ok -> nil
+          {:error, error} -> error
+        end
     }
   end
 

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -418,6 +418,12 @@ defmodule LivebookWeb.SessionLive do
     {:noreply, socket}
   end
 
+  def handle_event("set_cell_value", %{"cell_id" => cell_id, "value" => value}, socket) do
+    Session.set_cell_value(socket.assigns.session_id, cell_id, value)
+
+    {:noreply, socket}
+  end
+
   def handle_event("move_cell", %{"cell_id" => cell_id, "offset" => offset}, socket) do
     offset = ensure_integer(offset)
     Session.move_cell(socket.assigns.session_id, cell_id, offset)

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -181,8 +181,16 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       <div class="w-1 rounded-lg relative -left-3" data-element="cell-focus-indicator">
       </div>
       <div>
-        <div class="input-label">Name</div>
-        <input type="text" class="input" />
+        <!-- TODO: form? -->
+        <form phx-submit="set_cell_value" phx-change="set_cell_value">
+          <input type="hidden" name="cell_id" value="<%= @cell_view.id %>" />
+          <div class="input-label">Name</div>
+          <input type="text"
+            class="input"
+            name="value"
+            value="<%= @cell_view.value %>"
+            spellcheck="false" />
+        </form>
       </div>
     </div>
     """

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -184,7 +184,9 @@ defmodule LivebookWeb.SessionLive.CellComponent do
         <!-- TODO: form? -->
         <form phx-submit="set_cell_value" phx-change="set_cell_value">
           <input type="hidden" name="cell_id" value="<%= @cell_view.id %>" />
-          <div class="input-label">Name</div>
+          <div class="input-label">
+            <%= @cell_view.name %>
+          </div>
           <input type="text"
             class="input"
             name="value"

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -192,11 +192,13 @@ defmodule LivebookWeb.SessionLive.CellComponent do
             <%= @cell_view.name %>
           </div>
           <input type="text"
+            data-element="input"
             class="input"
             name="value"
             value="<%= @cell_view.value %>"
             spellcheck="false"
-            autocomplete="off" />
+            autocomplete="off"
+            tabindex="-1" />
         </form>
       </div>
     </div>

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -186,7 +186,6 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       <div class="w-1 rounded-lg relative -left-3" data-element="cell-focus-indicator">
       </div>
       <div>
-        <!-- TODO: form? -->
         <form phx-change="set_cell_value" onsubmit="return false">
           <input type="hidden" name="cell_id" value="<%= @cell_view.id %>" />
           <div class="input-label">

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -193,12 +193,17 @@ defmodule LivebookWeb.SessionLive.CellComponent do
           </div>
           <input type="text"
             data-element="input"
-            class="input"
+            class="input <%= if(@cell_view.error, do: "input--error") %>"
             name="value"
             value="<%= @cell_view.value %>"
             spellcheck="false"
             autocomplete="off"
             tabindex="-1" />
+          <%= if @cell_view.error do %>
+            <div class="input-error">
+              <%= String.capitalize(@cell_view.error) %>
+            </div>
+          <% end %>
         </form>
       </div>
     </div>

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -146,6 +146,48 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     """
   end
 
+  def render_cell_content(%{cell_view: %{type: :input}} = assigns) do
+    ~L"""
+    <div class="mb-1 flex items-center justify-end">
+      <div class="relative z-10 flex items-center justify-end space-x-2" data-element="actions">
+        <%= render_cell_anchor_link(assigns) %>
+        <span class="tooltip top" aria-label="Move up">
+          <button class="icon-button"
+            phx-click="move_cell"
+            phx-value-cell_id="<%= @cell_view.id %>"
+            phx-value-offset="-1">
+            <%= remix_icon("arrow-up-s-line", class: "text-xl") %>
+          </button>
+        </span>
+        <span class="tooltip top" aria-label="Move down">
+          <button class="icon-button"
+            phx-click="move_cell"
+            phx-value-cell_id="<%= @cell_view.id %>"
+            phx-value-offset="1">
+            <%= remix_icon("arrow-down-s-line", class: "text-xl") %>
+          </button>
+        </span>
+        <span class="tooltip top" aria-label="Delete">
+          <button class="icon-button"
+            phx-click="delete_cell"
+            phx-value-cell_id="<%= @cell_view.id %>">
+            <%= remix_icon("delete-bin-6-line", class: "text-xl") %>
+          </button>
+        </span>
+      </div>
+    </div>
+
+    <div class="flex">
+      <div class="w-1 rounded-lg relative -left-3" data-element="cell-focus-indicator">
+      </div>
+      <div>
+        <div class="input-label">Name</div>
+        <input type="text" class="input" />
+      </div>
+    </div>
+    """
+  end
+
   defp render_editor(assigns) do
     ~L"""
     <div class="py-3 rounded-lg bg-editor relative">

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -151,6 +151,11 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     <div class="mb-1 flex items-center justify-end">
       <div class="relative z-10 flex items-center justify-end space-x-2" data-element="actions">
         <%= render_cell_anchor_link(assigns) %>
+        <span class="tooltip top" aria-label="Cell settings">
+          <%= live_patch to: Routes.session_path(@socket, :cell_settings, @session_id, @cell_view.id), class: "icon-button" do %>
+            <%= remix_icon("list-settings-line", class: "text-xl") %>
+          <% end %>
+        </span>
         <span class="tooltip top" aria-label="Move up">
           <button class="icon-button"
             phx-click="move_cell"
@@ -182,7 +187,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       </div>
       <div>
         <!-- TODO: form? -->
-        <form phx-submit="set_cell_value" phx-change="set_cell_value">
+        <form phx-change="set_cell_value" onsubmit="return false">
           <input type="hidden" name="cell_id" value="<%= @cell_view.id %>" />
           <div class="input-label">
             <%= @cell_view.name %>
@@ -191,7 +196,8 @@ defmodule LivebookWeb.SessionLive.CellComponent do
             class="input"
             name="value"
             value="<%= @cell_view.value %>"
-            spellcheck="false" />
+            spellcheck="false"
+            autocomplete="off" />
         </form>
       </div>
     </div>

--- a/lib/livebook_web/live/session_live/cell_settings_component.ex
+++ b/lib/livebook_web/live/session_live/cell_settings_component.ex
@@ -56,3 +56,53 @@ defmodule LivebookWeb.SessionLive.CellSettingsComponent do
     end
   end
 end
+
+# TODO: naming and structure (?)
+defmodule LivebookWeb.SessionLive.InputCellSettingsComponent do
+  use LivebookWeb, :live_component
+
+  alias Livebook.Session
+
+  @impl true
+  def update(assigns, socket) do
+    cell = assigns.cell
+
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(name: cell.name)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~L"""
+    <div class="p-6 pb-4 flex flex-col space-y-8">
+      <h3 class="text-2xl font-semibold text-gray-800">
+        Cell settings
+      </h3>
+      <form phx-submit="save" phx-target="<%= @myself %>">
+        <div>
+          <div class="input-label">Name</div>
+          <input type="text" class="input" name="name" value="<%= @name %>" spellcheck="false" autofocus />
+        </div>
+        <div class="mt-8 flex justify-end space-x-2">
+          <%= live_patch "Cancel", to: @return_to, class: "button button-outlined-gray" %>
+          <button class="button button-blue" type="submit">
+            Save
+          </button>
+        </div>
+      </form>
+    </div>
+    """
+  end
+
+  # TODO: validation
+
+  @impl true
+  def handle_event("save", %{"name" => name}, socket) do
+    Session.set_cell_attributes(socket.assigns.session_id, socket.assigns.cell.id, %{name: name})
+    {:noreply, push_patch(socket, to: socket.assigns.return_to)}
+  end
+end

--- a/lib/livebook_web/live/session_live/elixir_cell_settings_component.ex
+++ b/lib/livebook_web/live/session_live/elixir_cell_settings_component.ex
@@ -1,4 +1,4 @@
-defmodule LivebookWeb.SessionLive.CellSettingsComponent do
+defmodule LivebookWeb.SessionLive.ElixirCellSettingsComponent do
   use LivebookWeb, :live_component
 
   alias Livebook.Session
@@ -54,55 +54,5 @@ defmodule LivebookWeb.SessionLive.CellSettingsComponent do
     else
       Map.delete(metadata, "disable_formatting")
     end
-  end
-end
-
-# TODO: naming and structure (?)
-defmodule LivebookWeb.SessionLive.InputCellSettingsComponent do
-  use LivebookWeb, :live_component
-
-  alias Livebook.Session
-
-  @impl true
-  def update(assigns, socket) do
-    cell = assigns.cell
-
-    socket =
-      socket
-      |> assign(assigns)
-      |> assign(name: cell.name)
-
-    {:ok, socket}
-  end
-
-  @impl true
-  def render(assigns) do
-    ~L"""
-    <div class="p-6 pb-4 flex flex-col space-y-8">
-      <h3 class="text-2xl font-semibold text-gray-800">
-        Cell settings
-      </h3>
-      <form phx-submit="save" phx-target="<%= @myself %>">
-        <div>
-          <div class="input-label">Name</div>
-          <input type="text" class="input" name="name" value="<%= @name %>" spellcheck="false" autofocus />
-        </div>
-        <div class="mt-8 flex justify-end space-x-2">
-          <%= live_patch "Cancel", to: @return_to, class: "button button-outlined-gray" %>
-          <button class="button button-blue" type="submit">
-            Save
-          </button>
-        </div>
-      </form>
-    </div>
-    """
-  end
-
-  # TODO: validation
-
-  @impl true
-  def handle_event("save", %{"name" => name}, socket) do
-    Session.set_cell_attributes(socket.assigns.session_id, socket.assigns.cell.id, %{name: name})
-    {:noreply, push_patch(socket, to: socket.assigns.return_to)}
   end
 end

--- a/lib/livebook_web/live/session_live/elixir_cell_settings_component.ex
+++ b/lib/livebook_web/live/session_live/elixir_cell_settings_component.ex
@@ -45,9 +45,9 @@ defmodule LivebookWeb.SessionLive.ElixirCellSettingsComponent do
   def handle_event("save", params, socket) do
     metadata = update_metadata(socket.assigns.cell.metadata, params)
 
-    Session.set_cell_attributes(socket.assigns.session_id, socket.assigns.cell.id,
-      %{metadata: metadata}
-    )
+    Session.set_cell_attributes(socket.assigns.session_id, socket.assigns.cell.id, %{
+      metadata: metadata
+    })
 
     {:noreply, push_patch(socket, to: socket.assigns.return_to)}
   end

--- a/lib/livebook_web/live/session_live/elixir_cell_settings_component.ex
+++ b/lib/livebook_web/live/session_live/elixir_cell_settings_component.ex
@@ -44,7 +44,11 @@ defmodule LivebookWeb.SessionLive.ElixirCellSettingsComponent do
   @impl true
   def handle_event("save", params, socket) do
     metadata = update_metadata(socket.assigns.cell.metadata, params)
-    Session.set_cell_metadata(socket.assigns.session_id, socket.assigns.cell.id, metadata)
+
+    Session.set_cell_attributes(socket.assigns.session_id, socket.assigns.cell.id,
+      %{metadata: metadata}
+    )
+
     {:noreply, push_patch(socket, to: socket.assigns.return_to)}
   end
 

--- a/lib/livebook_web/live/session_live/input_cell_settings_component.ex
+++ b/lib/livebook_web/live/session_live/input_cell_settings_component.ex
@@ -10,7 +10,7 @@ defmodule LivebookWeb.SessionLive.InputCellSettingsComponent do
     socket =
       socket
       |> assign(assigns)
-      |> assign(name: cell.name)
+      |> assign(name: cell.name, type: cell.type)
 
     {:ok, socket}
   end
@@ -26,6 +26,9 @@ defmodule LivebookWeb.SessionLive.InputCellSettingsComponent do
         <div>
           <div class="input-label">Name</div>
           <input type="text" class="input" name="name" value="<%= @name %>" spellcheck="false" autocomplete="off" autofocus />
+        </div>
+        <div class="mt-4 flex space-x-8 items-center">
+          <%= render_radios("type", [text: "Text", url: "URL"], @type) %>
         </div>
         <div class="mt-8 flex justify-end space-x-2">
           <%= live_patch "Cancel", to: @return_to, class: "button button-outlined-gray" %>
@@ -44,8 +47,10 @@ defmodule LivebookWeb.SessionLive.InputCellSettingsComponent do
     {:noreply, assign(socket, name: name)}
   end
 
-  def handle_event("save", %{"name" => name}, socket) do
-    Session.set_cell_attributes(socket.assigns.session_id, socket.assigns.cell.id, %{name: name})
+  def handle_event("save", %{"name" => name, "type" => type}, socket) do
+    type = String.to_existing_atom(type)
+    attrs = %{name: name, type: type}
+    Session.set_cell_attributes(socket.assigns.session_id, socket.assigns.cell.id, attrs)
     {:noreply, push_patch(socket, to: socket.assigns.return_to)}
   end
 end

--- a/lib/livebook_web/live/session_live/input_cell_settings_component.ex
+++ b/lib/livebook_web/live/session_live/input_cell_settings_component.ex
@@ -1,0 +1,51 @@
+defmodule LivebookWeb.SessionLive.InputCellSettingsComponent do
+  use LivebookWeb, :live_component
+
+  alias Livebook.Session
+
+  @impl true
+  def update(assigns, socket) do
+    cell = assigns.cell
+
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(name: cell.name)
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~L"""
+    <div class="p-6 pb-4 flex flex-col space-y-8">
+      <h3 class="text-2xl font-semibold text-gray-800">
+        Cell settings
+      </h3>
+      <form phx-submit="save" phx-change="validate" phx-target="<%= @myself %>">
+        <div>
+          <div class="input-label">Name</div>
+          <input type="text" class="input" name="name" value="<%= @name %>" spellcheck="false" autocomplete="off" autofocus />
+        </div>
+        <div class="mt-8 flex justify-end space-x-2">
+          <%= live_patch "Cancel", to: @return_to, class: "button button-outlined-gray" %>
+          <%= content_tag :button, "Save",
+                type: :submit,
+                class: "button button-blue",
+                disabled: @name == "" %>
+        </div>
+      </form>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_event("validate", %{"name" => name}, socket) do
+    {:noreply, assign(socket, name: name)}
+  end
+
+  def handle_event("save", %{"name" => name}, socket) do
+    Session.set_cell_attributes(socket.assigns.session_id, socket.assigns.cell.id, %{name: name})
+    {:noreply, push_patch(socket, to: socket.assigns.return_to)}
+  end
+end

--- a/lib/livebook_web/live/session_live/input_cell_settings_component.ex
+++ b/lib/livebook_web/live/session_live/input_cell_settings_component.ex
@@ -10,7 +10,8 @@ defmodule LivebookWeb.SessionLive.InputCellSettingsComponent do
     socket =
       socket
       |> assign(assigns)
-      |> assign(name: cell.name, type: cell.type)
+      |> assign_new(:name, fn -> cell.name end)
+      |> assign_new(:type, fn -> cell.type end)
 
     {:ok, socket}
   end

--- a/lib/livebook_web/live/session_live/insert_buttons_component.ex
+++ b/lib/livebook_web/live/session_live/insert_buttons_component.ex
@@ -17,6 +17,12 @@ defmodule LivebookWeb.SessionLive.InsertButtonsComponent do
           phx-value-section_id="<%= @section_id %>"
           phx-value-index="<%= @insert_cell_index %>"
           >+ Elixir</button>
+        <button class="button button-small"
+          phx-click="insert_cell"
+          phx-value-type="input"
+          phx-value-section_id="<%= @section_id %>"
+          phx-value-index="<%= @insert_cell_index %>"
+          >+ Input</button>
         <%= if @insert_section_index do %>
           <button class="button button-small"
             phx-click="insert_section"

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -31,6 +31,7 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
       %{seq: ["ej"], desc: "Evaluate cells below"},
       %{seq: ["ex"], desc: "Cancel cell evaluation"},
       %{seq: ["ss"], desc: "Toggle sections panel"},
+      %{seq: ["su"], desc: "Toggle users panel"},
       %{seq: ["sr"], desc: "Show runtime settings"}
     ],
     universal: [

--- a/test/livebook/evaluator/io_proxy_test.exs
+++ b/test/livebook/evaluator/io_proxy_test.exs
@@ -52,6 +52,20 @@ defmodule Livebook.Evaluator.IOProxyTest do
 
       assert IO.gets(io, "name: ") == "Jake Peralta"
     end
+
+    test "IO.gets :eof", %{io: io} do
+      pid =
+        spawn(fn ->
+          receive do
+            {:evaluation_input, :ref, ^io, "name: "} ->
+              send(io, {:evaluation_input_reply, :error})
+          end
+        end)
+
+      IOProxy.configure(io, pid, :ref)
+
+      assert IO.gets(io, "name: ") == :eof
+    end
   end
 
   test "buffers rapid output", %{io: io} do

--- a/test/livebook/evaluator/io_proxy_test.exs
+++ b/test/livebook/evaluator/io_proxy_test.exs
@@ -36,7 +36,7 @@ defmodule Livebook.Evaluator.IOProxyTest do
 
       IOProxy.configure(io, pid, :ref)
 
-      assert IO.read(io, :all) == ""
+      assert IO.read(io, :all) == {:error, "no matching Livebook input found"}
     end
 
     test "IO.gets", %{io: io} do
@@ -53,7 +53,7 @@ defmodule Livebook.Evaluator.IOProxyTest do
       assert IO.gets(io, "name: ") == "Jake Peralta"
     end
 
-    test "IO.gets :eof", %{io: io} do
+    test "IO.gets with no matching input", %{io: io} do
       pid =
         spawn(fn ->
           receive do
@@ -64,7 +64,7 @@ defmodule Livebook.Evaluator.IOProxyTest do
 
       IOProxy.configure(io, pid, :ref)
 
-      assert IO.gets(io, "name: ") == :eof
+      assert IO.gets(io, "name: ") == {:error, "no matching Livebook input found"}
     end
   end
 

--- a/test/livebook/evaluator/io_proxy_test.exs
+++ b/test/livebook/evaluator/io_proxy_test.exs
@@ -27,11 +27,8 @@ defmodule Livebook.Evaluator.IOProxyTest do
 
     test "IO.read", %{io: io} do
       pid =
-        spawn(fn ->
-          receive do
-            {:evaluation_input, :ref, ^io, ""} ->
-              send(io, {:evaluation_input_reply, :error})
-          end
+        spawn_link(fn ->
+          reply_to_input_request(:ref, "", :error, 1)
         end)
 
       IOProxy.configure(io, pid, :ref)
@@ -41,11 +38,8 @@ defmodule Livebook.Evaluator.IOProxyTest do
 
     test "IO.gets", %{io: io} do
       pid =
-        spawn(fn ->
-          receive do
-            {:evaluation_input, :ref, ^io, "name: "} ->
-              send(io, {:evaluation_input_reply, {:ok, "Jake Peralta"}})
-          end
+        spawn_link(fn ->
+          reply_to_input_request(:ref, "name: ", {:ok, "Jake Peralta"}, 1)
         end)
 
       IOProxy.configure(io, pid, :ref)
@@ -55,17 +49,40 @@ defmodule Livebook.Evaluator.IOProxyTest do
 
     test "IO.gets with no matching input", %{io: io} do
       pid =
-        spawn(fn ->
-          receive do
-            {:evaluation_input, :ref, ^io, "name: "} ->
-              send(io, {:evaluation_input_reply, :error})
-          end
+        spawn_link(fn ->
+          reply_to_input_request(:ref, "name: ", :error, 1)
         end)
 
       IOProxy.configure(io, pid, :ref)
 
       assert IO.gets(io, "name: ") == {:error, "no matching Livebook input found"}
     end
+  end
+
+  test "consumes the given input only once", %{io: io} do
+    pid =
+      spawn_link(fn ->
+        reply_to_input_request(:ref, "name: ", {:ok, "Jake Peralta\nAmy Santiago\n"}, 1)
+      end)
+
+    IOProxy.configure(io, pid, :ref)
+
+    assert IO.gets(io, "name: ") == "Jake Peralta\n"
+    assert IO.gets(io, "name: ") == "Amy Santiago\n"
+    assert IO.gets(io, "name: ") == :eof
+  end
+
+  test "clear_input_buffers/1 clears all buffered input information", %{io: io} do
+    pid =
+      spawn_link(fn ->
+        reply_to_input_request(:ref, "name: ", {:ok, "Jake Peralta"}, 2)
+      end)
+
+    IOProxy.configure(io, pid, :ref)
+
+    assert IO.gets(io, "name: ") == "Jake Peralta"
+    IOProxy.clear_input_buffers(io)
+    assert IO.gets(io, "name: ") == "Jake Peralta"
   end
 
   test "buffers rapid output", %{io: io} do
@@ -92,5 +109,17 @@ defmodule Livebook.Evaluator.IOProxyTest do
     assert_receive {:io_reply, ^ref, :ok}
 
     assert_received {:evaluation_output, :ref, {:text, "[1, 2, 3]"}}
+  end
+
+  # Helpers
+
+  defp reply_to_input_request(_ref, _prompt, _reply, 0), do: :ok
+
+  defp reply_to_input_request(ref, prompt, reply, times) do
+    receive do
+      {:evaluation_input, ^ref, reply_to, ^prompt} ->
+        send(reply_to, {:evaluation_input_reply, reply})
+        reply_to_input_request(ref, prompt, reply, times - 1)
+    end
   end
 end

--- a/test/livebook/evaluator_test.exs
+++ b/test/livebook/evaluator_test.exs
@@ -55,10 +55,13 @@ defmodule Livebook.EvaluatorTest do
       assert_receive {:evaluation_output, :code_1, "hey\n"}
     end
 
-    test "using standard input results in an immediate error", %{evaluator: evaluator} do
-      Evaluator.evaluate_code(evaluator, self(), ~s{IO.gets("> ")}, :code_1)
+    test "using standard input sends input request to the caller", %{evaluator: evaluator} do
+      Evaluator.evaluate_code(evaluator, self(), ~s{IO.gets("name: ")}, :code_1)
 
-      assert_receive {:evaluation_response, :code_1, {:ok, {:error, :enotsup}}}
+      assert_receive {:evaluation_input, :code_1, reply_to, "name: "}
+      send(reply_to, {:evaluation_input_reply, {:ok, "Jake Peralta\n"}})
+
+      assert_receive {:evaluation_response, :code_1, {:ok, "Jake Peralta\n"}}
     end
 
     test "returns error along with its kind and stacktrace", %{evaluator: evaluator} do

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -48,10 +48,16 @@ defmodule Livebook.LiveMarkdown.ExportTest do
               metadata: %{},
               cells: [
                 %{
+                  Notebook.Cell.new(:input)
+                  | type: :text,
+                    name: "length",
+                    value: "100"
+                },
+                %{
                   Notebook.Cell.new(:elixir)
                   | metadata: %{},
                     source: """
-                    # More Elixir code\
+                    IO.gets("length: ")
                     """
                 }
               ]
@@ -86,8 +92,10 @@ defmodule Livebook.LiveMarkdown.ExportTest do
 
     ## Section 2
 
+    <!-- livebook:{"livebook_object":"cell_input","name":"length","type":"text","value":"100"} -->
+
     ```elixir
-    # More Elixir code
+    IO.gets("length: ")
     ```
     """
 

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -33,8 +33,10 @@ defmodule Livebook.LiveMarkdown.ImportTest do
 
     ## Section 2
 
+    <!-- livebook:{"livebook_object":"cell_input","name":"length","type":"text","value":"100"} -->
+
     ```elixir
-    # More Elixir code
+    IO.gets("length: ")
     ```
     """
 
@@ -78,10 +80,16 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                  name: "Section 2",
                  metadata: %{},
                  cells: [
+                   %Cell.Input{
+                     metadata: %{},
+                     type: :text,
+                     name: "length",
+                     value: "100"
+                   },
                    %Cell.Elixir{
                      metadata: %{},
                      source: """
-                     # More Elixir code\
+                     IO.gets("length: ")\
                      """
                    }
                  ]

--- a/test/livebook/live_markdown/import_test.exs
+++ b/test/livebook/live_markdown/import_test.exs
@@ -3,6 +3,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
 
   alias Livebook.LiveMarkdown.Import
   alias Livebook.Notebook
+  alias Livebook.Notebook.Cell
 
   test "acceptance" do
     markdown = """
@@ -49,8 +50,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                  name: "Section 1",
                  metadata: %{"created_at" => "2021-02-15"},
                  cells: [
-                   %Notebook.Cell{
-                     type: :markdown,
+                   %Cell.Markdown{
                      metadata: %{"updated_at" => "2021-02-15"},
                      source: """
                      Make sure to install:
@@ -60,15 +60,13 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                      * PostgreSQL\
                      """
                    },
-                   %Notebook.Cell{
-                     type: :elixir,
+                   %Cell.Elixir{
                      metadata: %{"readonly" => true},
                      source: """
                      Enum.to_list(1..10)\
                      """
                    },
-                   %Notebook.Cell{
-                     type: :markdown,
+                   %Cell.Markdown{
                      metadata: %{},
                      source: """
                      This is it for this section.\
@@ -80,7 +78,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                  name: "Section 2",
                  metadata: %{},
                  cells: [
-                   %Notebook.Cell{
+                   %Cell.Elixir{
                      metadata: %{},
                      source: """
                      # More Elixir code\
@@ -116,8 +114,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                  name: "Section 1",
                  metadata: %{},
                  cells: [
-                   %Notebook.Cell{
-                     type: :markdown,
+                   %Cell.Markdown{
                      metadata: %{},
                      source: """
                      Line 1.\\
@@ -175,8 +172,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                %Notebook.Section{
                  name: "Probably section 1",
                  cells: [
-                   %Notebook.Cell{
-                     type: :markdown,
+                   %Cell.Markdown{
                      metadata: %{},
                      source: """
                      ### Heading
@@ -189,8 +185,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                %Notebook.Section{
                  name: "Probably section 2",
                  cells: [
-                   %Notebook.Cell{
-                     type: :markdown,
+                   %Cell.Markdown{
                      metadata: %{},
                      source: """
                      **Tiny heading**\
@@ -240,8 +235,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                %Notebook.Section{
                  name: "Section",
                  cells: [
-                   %Notebook.Cell{
-                     type: :markdown,
+                   %Cell.Markdown{
                      source: """
                      Some markdown.\
                      """
@@ -270,8 +264,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                %Notebook.Section{
                  name: "Section",
                  cells: [
-                   %Notebook.Cell{
-                     type: :elixir,
+                   %Cell.Elixir{
                      source: """
                      Enum.to_list(1..10)\
                      """
@@ -302,8 +295,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                %Notebook.Section{
                  name: "Section",
                  cells: [
-                   %Notebook.Cell{
-                     type: :markdown,
+                   %Cell.Markdown{
                      source: """
                      Cool notebook.
 
@@ -359,22 +351,19 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                %Notebook.Section{
                  name: "Section 1",
                  cells: [
-                   %Notebook.Cell{
-                     type: :markdown,
+                   %Cell.Markdown{
                      source: """
                      ```shell
                      mix deps.get
                      ```\
                      """
                    },
-                   %Notebook.Cell{
-                     type: :elixir,
+                   %Cell.Elixir{
                      source: """
                      Enum.to_list(1..10)\
                      """
                    },
-                   %Notebook.Cell{
-                     type: :markdown,
+                   %Cell.Markdown{
                      source: """
                      ```erlang
                      spawn_link(fun() -> io:format("Hiya") end).
@@ -418,8 +407,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                %Notebook.Section{
                  name: "Section 1",
                  cells: [
-                   %Notebook.Cell{
-                     type: :markdown,
+                   %Cell.Markdown{
                      source: """
                      ```elixir
                      [1, 2, 3]
@@ -431,8 +419,7 @@ defmodule Livebook.LiveMarkdown.ImportTest do
                %Notebook.Section{
                  name: "Section 2",
                  cells: [
-                   %Notebook.Cell{
-                     type: :markdown,
+                   %Cell.Markdown{
                      source: """
                      Some markdown.
 

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -1642,6 +1642,25 @@ defmodule Livebook.Session.DataTest do
                 }
               }, _} = Data.apply_operation(data, operation)
     end
+
+    test "given input value change, marks evaluated child cells as stale" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_cell, self(), "s1", 0, :input, "c1"},
+          {:insert_cell, self(), "s1", 1, :elixir, "c2"},
+          {:queue_cell_evaluation, self(), "c2"},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, [1, 2, 3]}}
+        ])
+
+      attrs = %{value: "stuff"}
+      operation = {:set_cell_attributes, self(), "c1", attrs}
+
+      assert {:ok,
+              %{
+                cell_infos: %{"c2" => %{validity_status: :stale}}
+              }, _} = Data.apply_operation(data, operation)
+    end
   end
 
   describe "apply_operation/2 given :set_runtime" do

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -3,6 +3,7 @@ defmodule Livebook.Session.DataTest do
 
   alias Livebook.Session.Data
   alias Livebook.{Delta, Notebook, Runtime}
+  alias Livebook.Notebook.Cell
   alias Livebook.Users.User
 
   describe "new/1" do
@@ -61,7 +62,7 @@ defmodule Livebook.Session.DataTest do
               %{
                 notebook: %{
                   sections: [
-                    %{cells: [%{id: "c1"}]}
+                    %{cells: [%Cell.Elixir{id: "c1"}]}
                   ]
                 },
                 cell_infos: %{"c1" => _}

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -461,7 +461,7 @@ defmodule Livebook.SessionTest do
                       {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output}}},
                      @evaluation_wait_timeout
 
-      assert text_output =~ ":eof"
+      assert text_output =~ "no matching Livebook input found"
     end
 
     test "replies with error when the matching input is invalid" do
@@ -492,7 +492,7 @@ defmodule Livebook.SessionTest do
                       {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output}}},
                      @evaluation_wait_timeout
 
-      assert text_output =~ ":eof"
+      assert text_output =~ "no matching Livebook input found"
     end
   end
 

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -152,16 +152,16 @@ defmodule Livebook.SessionTest do
     end
   end
 
-  describe "set_cell_metadata/3" do
-    test "sends a metadata update operation to subscribers", %{session_id: session_id} do
+  describe "set_cell_attributes/3" do
+    test "sends an attributes update operation to subscribers", %{session_id: session_id} do
       Phoenix.PubSub.subscribe(Livebook.PubSub, "sessions:#{session_id}")
       pid = self()
 
       {_section_id, cell_id} = insert_section_and_cell(session_id)
-      metadata = %{"disable_formatting" => true}
+      attrs = %{metadata: %{"disable_formatting" => true}}
 
-      Session.set_cell_metadata(session_id, cell_id, metadata)
-      assert_receive {:operation, {:set_cell_metadata, ^pid, ^cell_id, ^metadata}}
+      Session.set_cell_attributes(session_id, cell_id, attrs)
+      assert_receive {:operation, {:set_cell_attributes, ^pid, ^cell_id, ^attrs}}
     end
   end
 

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -4,6 +4,7 @@ defmodule LivebookWeb.SessionLiveTest do
   import Phoenix.LiveViewTest
 
   alias Livebook.{SessionSupervisor, Session, Delta, Runtime, Users}
+  alias Livebook.Notebook.Cell
   alias Livebook.Users.User
 
   setup do
@@ -89,7 +90,7 @@ defmodule LivebookWeb.SessionLiveTest do
       |> element("button", "+ Markdown")
       |> render_click()
 
-      assert %{notebook: %{sections: [%{cells: [%{type: :markdown}]}]}} =
+      assert %{notebook: %{sections: [%{cells: [%Cell.Markdown{}]}]}} =
                Session.get_data(session_id)
     end
 
@@ -135,7 +136,7 @@ defmodule LivebookWeb.SessionLiveTest do
       |> element("#session")
       |> render_hook("insert_cell_below", %{"cell_id" => cell_id, "type" => "markdown"})
 
-      assert %{notebook: %{sections: [%{cells: [_first_cell, %{type: :markdown}]}]}} =
+      assert %{notebook: %{sections: [%{cells: [_first_cell, %Cell.Markdown{}]}]}} =
                Session.get_data(session_id)
     end
 
@@ -149,7 +150,7 @@ defmodule LivebookWeb.SessionLiveTest do
       |> element("#session")
       |> render_hook("insert_cell_above", %{"cell_id" => cell_id, "type" => "markdown"})
 
-      assert %{notebook: %{sections: [%{cells: [%{type: :markdown}, _first_cell]}]}} =
+      assert %{notebook: %{sections: [%{cells: [%Cell.Markdown{}, _first_cell]}]}} =
                Session.get_data(session_id)
     end
 


### PR DESCRIPTION
Closes #213.

## Summary

We now have input cells that allow the user to a specify value for the given prompt. The value can be read in Elixir cells by doing `IO.gets("input name")`, `IO.gets("input name: ")`, and similar, as long as the prompt starts with input name. We took this approach, so that there is no magic in the user code and it stays valid outside of Livebook (when run as a script).

## Communication

The `Runtime` protocol is extended to allow sending `{:evaluation_input, ref, reply_to, prompt}` to Livebook and expecting a reply with either the input value or an error if none matches. The `IOProxy` uses this contract whenever it receives a `:get_line` request.

So far we only had Markdown and Elixir cells, which are very much alike, so they were represented as `%Cell{type: ...}`. Now, as cell types started to diverge, I broke this apart into individual structures (although the view part stays pretty much the same, due to the use of `data_view`).

## Persistence

The inputs have a number of properties, so there's no clear Markdown encoding for that and consequently we stick to the JSON comments. An input is persisted like so:

```markdown
<!-- livebook:{"livebook_object":"cell_input","name":"length","type":"text","value":"100"} -->
```

We use the `livebook:` prefix for any JSON we store, whether it's metadata or some other kind of attributes. To identify a particular comment as a cell, there is a `"livebook_object"` property, and with this approach it should be easy to add similar objects later.

## Demo

https://user-images.githubusercontent.com/17034772/121067306-2c45ea00-c7cb-11eb-80ba-51d2830461d0.mp4