### PR TITLE
fix markdown codeblocks overflowing container

### DIFF
--- a/assets/css/markdown.css
+++ b/assets/css/markdown.css
@@ -109,8 +109,12 @@
   @apply py-[0.1rem] px-2 rounded-lg text-sm align-middle font-mono bg-gray-200;
 }
 
+.markdown pre {
+  @apply flex overflow-hidden;
+}
+
 .markdown pre > code {
-  @apply block p-4 rounded-lg text-sm align-middle font-mono;
+  @apply p-4 rounded-lg text-sm align-middle font-mono flex-1 overflow-auto;
   /* Match the editor colors */
   background-color: #282c34;
   color: #abb2bf;


### PR DESCRIPTION
This PR addresses issue [#327](https://github.com/elixir-nx/livebook/issues/327).

As discussed in the issue, adding text wrapping to code blocks might not be the best approach, since it's better to encourage users to break lines manually. The proposed fix simply adds a couple of tailwindcss classes to prevent long single-line code blocks from flowing out of the parent container. This is the same approach adopted by Github's markdown preview.

### Before
![before](https://user-images.githubusercontent.com/53831919/121280571-e7927f80-c8ac-11eb-9485-fb68e2a524fb.jpg)

### After
![after](https://user-images.githubusercontent.com/53831919/121280568-e6f9e900-c8ac-11eb-92f0-fc2241b7baf5.jpg)


