### PR TITLE
Compute cell source digest on the client

### DIFF
--- a/assets/css/js_interop.css
+++ b/assets/css/js_interop.css
@@ -60,6 +60,10 @@ solely client-side operations.
   @apply opacity-100 pointer-events-auto;
 }
 
+[data-element="cell"] [data-element="change-indicator"]:not([data-js-shown]) {
+  @apply invisible;
+}
+
 [data-element="sections-list-item"][data-js-is-viewed] {
   @apply text-gray-900;
 }

--- a/assets/js/cell/live_editor.js
+++ b/assets/js/cell/live_editor.js
@@ -49,6 +49,13 @@ class LiveEditor {
   }
 
   /**
+   * Returns current editor content.
+   */
+  getSource() {
+    return this.source;
+  }
+
+  /**
    * Registers a callback called with a new cell content whenever it changes.
    */
   onChange(callback) {

--- a/assets/js/lib/utils.js
+++ b/assets/js/lib/utils.js
@@ -1,3 +1,6 @@
+import md5 from "crypto-js/md5";
+import encBase64 from "crypto-js/enc-base64";
+
 export function isMacOS() {
   return /(Mac|iPhone|iPod|iPad)/i.test(navigator.platform);
 }
@@ -72,4 +75,12 @@ export function randomId() {
   crypto.getRandomValues(array);
   const byteString = String.fromCharCode(...array);
   return btoa(byteString);
+}
+
+/**
+ * Calculates MD5 of the given string and returns
+ * the base64 encoded binary.
+ */
+export function md5Base64(string) {
+  return md5(string).toString(encBase64);
 }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -8,6 +8,7 @@
       "dependencies": {
         "@fontsource/inter": "^4.2.2",
         "@fontsource/jetbrains-mono": "^4.2.2",
+        "crypto-js": "^4.0.0",
         "dompurify": "^2.2.6",
         "hyperlist": "^1.0.0",
         "katex": "^0.13.2",
@@ -45,14 +46,14 @@
       }
     },
     "../deps/phoenix": {
-      "version": "1.5.8",
+      "version": "1.5.9",
       "license": "MIT"
     },
     "../deps/phoenix_html": {
       "version": "2.14.3"
     },
     "../deps/phoenix_live_view": {
-      "version": "0.15.5",
+      "version": "0.15.7",
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -3588,6 +3589,11 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "node_modules/css-color-names": {
       "version": "0.0.4",
@@ -14902,6 +14908,11 @@
           }
         }
       }
+    },
+    "crypto-js": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.0.0.tgz",
+      "integrity": "sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg=="
     },
     "css-color-names": {
       "version": "0.0.4",

--- a/assets/package.json
+++ b/assets/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@fontsource/inter": "^4.2.2",
     "@fontsource/jetbrains-mono": "^4.2.2",
+    "crypto-js": "^4.0.0",
     "dompurify": "^2.2.6",
     "hyperlist": "^1.0.0",
     "katex": "^0.13.2",

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -687,7 +687,9 @@ defmodule Livebook.Session do
 
     Runtime.evaluate_code(state.data.runtime, cell.source, :main, cell.id, prev_ref, opts)
 
-    state
+    evaluation_digest = :erlang.md5(cell.source)
+
+    handle_operation(state, {:evaluation_started, self(), cell.id, evaluation_digest})
   end
 
   defp handle_action(state, {:stop_evaluation, _section}) do

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -222,7 +222,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
       <%= if @cell_view.type == :elixir do %>
         <div class="absolute bottom-2 right-2">
-          <%= render_cell_status(@cell_view.validity_status, @cell_view.evaluation_status, @cell_view.changed?) %>
+          <%= render_cell_status(@cell_view.validity_status, @cell_view.evaluation_status) %>
         </div>
       <% end %>
     </div>
@@ -363,43 +363,48 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     """
   end
 
-  defp render_cell_status(validity_status, evaluation_status, changed)
+  defp render_cell_status(validity_status, evaluation_status)
 
-  defp render_cell_status(_, :evaluating, changed) do
-    render_status_indicator("Evaluating", "bg-blue-500", "bg-blue-400", changed)
+  defp render_cell_status(_, :evaluating) do
+    render_status_indicator("Evaluating", "bg-blue-500",
+      animated_circle_class: "bg-blue-400",
+      change_indicator: true
+    )
   end
 
-  defp render_cell_status(_, :queued, _) do
-    render_status_indicator("Queued", "bg-gray-500", "bg-gray-400", false)
+  defp render_cell_status(_, :queued) do
+    render_status_indicator("Queued", "bg-gray-500", animated_circle_class: "bg-gray-400")
   end
 
-  defp render_cell_status(:evaluated, _, changed) do
-    render_status_indicator("Evaluated", "bg-green-400", nil, changed)
+  defp render_cell_status(:evaluated, _) do
+    render_status_indicator("Evaluated", "bg-green-400", change_indicator: true)
   end
 
-  defp render_cell_status(:stale, _, changed) do
-    render_status_indicator("Stale", "bg-yellow-200", nil, changed)
+  defp render_cell_status(:stale, _) do
+    render_status_indicator("Stale", "bg-yellow-200", change_indicator: true)
   end
 
-  defp render_cell_status(:aborted, _, _) do
-    render_status_indicator("Aborted", "bg-red-400", nil, false)
+  defp render_cell_status(:aborted, _) do
+    render_status_indicator("Aborted", "bg-red-400")
   end
 
-  defp render_cell_status(_, _, _), do: nil
+  defp render_cell_status(_, _), do: nil
 
-  defp render_status_indicator(text, circle_class, animated_circle_class, show_changed) do
+  defp render_status_indicator(text, circle_class, opts \\ []) do
     assigns = %{
       text: text,
       circle_class: circle_class,
-      animated_circle_class: animated_circle_class,
-      show_changed: show_changed
+      animated_circle_class: Keyword.get(opts, :animated_circle_class),
+      change_indicator: Keyword.get(opts, :change_indicator, false)
     }
 
     ~L"""
     <div class="flex items-center space-x-1">
       <div class="flex text-xs text-gray-400">
         <%= @text %>
-        <span class="<%= unless(@show_changed, do: "invisible") %>">*</span>
+        <%= if @change_indicator do %>
+          <span data-element="change-indicator">*</span>
+        <% end %>
       </div>
       <span class="flex relative h-3 w-3">
         <%= if @animated_circle_class do %>


### PR DESCRIPTION
Closes #337.

The client computes the content digest on its own, while the server only sends digest of evaluating cells, that the client then saves and uses for comparison.