### PR TITLE
Make table refetch an optional feature

### DIFF
--- a/lib/livebook_web/live/output/table_dynamic_live.ex
+++ b/lib/livebook_web/live/output/table_dynamic_live.ex
@@ -50,12 +50,14 @@ defmodule LivebookWeb.Output.TableDynamicLive do
       <div class="flex-grow"></div>
       <!-- Actions -->
       <div class="flex space-x-2">
-        <span class="tooltip left" aria-label="Refetch">
-          <%= tag :button, class: "icon-button",
-                phx_click: "refetch" %>
-            <%= remix_icon("refresh-line", class: "text-xl") %>
-          </button>
-        </span>
+        <%= if :refetch in @features do %>
+          <span class="tooltip left" aria-label="Refetch">
+            <%= tag :button, class: "icon-button",
+                  phx_click: "refetch" %>
+              <%= remix_icon("refresh-line", class: "text-xl") %>
+            </button>
+          </span>
+        <% end %>
       </div>
       <!-- Pagination -->
       <%= if :pagination in @features and @total_rows > 0 do %>


### PR DESCRIPTION
For some tables refetch may not make sense (static data), so we can keep it as an optional feature enabled by the widget process. Also see https://github.com/elixir-nx/kino/pull/15.