### PR TITLE
Show the evaluation time next to the cell indicator

### DIFF
--- a/assets/css/tooltips.css
+++ b/assets/css/tooltips.css
@@ -21,7 +21,7 @@ Example usage:
   --distance: 28px;
 }
 
-.tooltip.distant-less {
+.tooltip.distant-medium {
   --distance: 10px;
 }
 

--- a/assets/css/tooltips.css
+++ b/assets/css/tooltips.css
@@ -21,6 +21,10 @@ Example usage:
   --distance: 28px;
 }
 
+.tooltip.distant-less {
+  --distance: 10px;
+}
+
 /* Tooltip text */
 .tooltip:before {
   position: absolute;

--- a/lib/livebook/evaluator.ex
+++ b/lib/livebook/evaluator.ex
@@ -67,7 +67,7 @@ defmodule Livebook.Evaluator do
   Any subsequent calls may specify `prev_ref` pointing to a previous evaluation,
   in which case the corresponding binding and environment are used during evaluation.
 
-  Evaluation response is sent to the process identified by `send_to` as `{:evaluation_response, ref, response}`.
+  Evaluation response is sent to the process identified by `send_to` as `{:evaluation_response, ref, response, metadata}`.
   Note that response is transformed with the configured formatter (identity by default).
 
   ## Options
@@ -156,7 +156,7 @@ defmodule Livebook.Evaluator do
       end
 
     metadata = %{
-      evaluation_time_ms: get_execution_time_delta!(start_time)
+      evaluation_time_ms: get_execution_time_delta(start_time)
     }
 
     state = put_in(state.contexts[ref], result_context)
@@ -282,7 +282,7 @@ defmodule Livebook.Evaluator do
 
   def widget_pid_from_output(_output), do: :error
 
-  defp get_execution_time_delta!(started_at) do
+  defp get_execution_time_delta(started_at) do
     System.monotonic_time()
     |> Kernel.-(started_at)
     |> System.convert_time_unit(:native, :millisecond)

--- a/lib/livebook/evaluator.ex
+++ b/lib/livebook/evaluator.ex
@@ -142,11 +142,7 @@ defmodule Livebook.Evaluator do
     {result_context, response} =
       case eval(code, context.binding, context.env) do
         {:ok, result, binding, env} ->
-          result_context = %{
-            binding: binding,
-            env: env
-          }
-
+          result_context = %{binding: binding, env: env}
           response = {:ok, result}
           {result_context, response}
 
@@ -155,9 +151,7 @@ defmodule Livebook.Evaluator do
           {context, response}
       end
 
-    metadata = %{
-      evaluation_time_ms: get_execution_time_delta(start_time)
-    }
+    evaluation_time_ms = get_execution_time_delta(start_time)
 
     state = put_in(state.contexts[ref], result_context)
 
@@ -165,7 +159,7 @@ defmodule Livebook.Evaluator do
     Evaluator.IOProxy.clear_input_buffers(state.io_proxy)
 
     output = state.formatter.format_response(response)
-
+    metadata = %{evaluation_time_ms: evaluation_time_ms}
     send(send_to, {:evaluation_response, ref, output, metadata})
 
     widget_pids = Evaluator.IOProxy.flush_widgets(state.io_proxy)

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -20,7 +20,8 @@ defprotocol Livebook.Runtime do
           kind: completion_item_kind(),
           detail: String.t() | nil,
           documentation: String.t() | nil,
-          insert_text: String.t()
+          insert_text: String.t(),
+          evaluation_time_ms: float() | nil
         }
 
   @type completion_item_kind :: :function | :module | :type | :variable | :field

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -20,8 +20,7 @@ defprotocol Livebook.Runtime do
           kind: completion_item_kind(),
           detail: String.t() | nil,
           documentation: String.t() | nil,
-          insert_text: String.t(),
-          evaluation_time_ms: float() | nil
+          insert_text: String.t()
         }
 
   @type completion_item_kind :: :function | :module | :type | :variable | :field
@@ -54,7 +53,7 @@ defprotocol Livebook.Runtime do
   The messages should be of the form:
 
     * `{:evaluation_output, ref, output}` - output captured during evaluation
-    * `{:evaluation_response, ref, output}` - final result of the evaluation
+    * `{:evaluation_response, ref, output, metadata}` - final result of the evaluation, recognised metadata entries are: `evaluation_time_ms`
 
   The evaluation may request user input by sending `{:evaluation_input, ref, reply_to, prompt}`
   to the runtime owner, who is supposed to reply with `{:evaluation_input_reply, reply}`

--- a/lib/livebook/session.ex
+++ b/lib/livebook/session.ex
@@ -489,8 +489,8 @@ defmodule Livebook.Session do
     {:noreply, handle_operation(state, operation)}
   end
 
-  def handle_info({:evaluation_response, cell_id, response}, state) do
-    operation = {:add_cell_evaluation_response, self(), cell_id, response}
+  def handle_info({:evaluation_response, cell_id, response, metadata}, state) do
+    operation = {:add_cell_evaluation_response, self(), cell_id, response, metadata}
     {:noreply, handle_operation(state, operation)}
   end
 

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -299,7 +299,7 @@ defmodule Livebook.Session.Data do
       |> with_actions()
       |> add_cell_evaluation_response(cell, output)
       |> finish_cell_evaluation(cell, section)
-      |> add_cell_evaluation_time(cell, metadata.evaluation_time_ms)
+      |> finish_cell_evaluation(cell, metadata.evaluation_time_ms)
       |> mark_dependent_cells_as_stale(cell)
       |> maybe_evaluate_queued()
       |> wrap_ok()
@@ -613,7 +613,7 @@ defmodule Livebook.Session.Data do
     |> set_section_info!(section.id, evaluating_cell_id: nil)
   end
 
-  defp add_cell_evaluation_time(data_actions, cell, evaluation_time) do
+  defp finish_cell_evaluation(data_actions, cell, evaluation_time) do
     data_actions
     |> set_cell_info!(cell.id,
       evaluation_time_ms: evaluation_time

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -56,7 +56,6 @@ defmodule Livebook.Session.Data do
           deltas: list(Delta.t()),
           revision_by_client_pid: %{pid() => cell_revision()},
           evaluation_digest: String.t() | nil,
-          evaluation_start_time: float(),
           evaluation_time_ms: integer() | nil
         }
 
@@ -554,7 +553,6 @@ defmodule Livebook.Session.Data do
     end)
     |> set_cell_info!(cell.id,
       evaluation_status: :queued,
-      evaluation_start_time: System.monotonic_time()
     )
   end
 
@@ -891,8 +889,7 @@ defmodule Livebook.Session.Data do
       validity_status: :fresh,
       evaluation_status: :ready,
       evaluation_digest: nil,
-      evaluation_start_time: 0,
-      evaluation_time_ms: 0
+      evaluation_time_ms: nil
     }
   end
 

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -293,14 +293,14 @@ defmodule Livebook.Session.Data do
     end
   end
 
-  def apply_operation(data, {:add_cell_evaluation_response, _client_pid, id, output}) do
+  def apply_operation(data, {:add_cell_evaluation_response, _client_pid, id, output, metadata}) do
     with {:ok, cell, section} <- Notebook.fetch_cell_and_section(data.notebook, id),
          :evaluating <- data.cell_infos[cell.id].evaluation_status do
       data
       |> with_actions()
-      |> add_cell_evaluation_response(cell, output.response)
+      |> add_cell_evaluation_response(cell, output)
       |> finish_cell_evaluation(cell, section)
-      |> add_cell_evaluation_time(cell, output.evaluation_time_ms)
+      |> add_cell_evaluation_time(cell, metadata.evaluation_time_ms)
       |> mark_dependent_cells_as_stale(cell)
       |> maybe_evaluate_queued()
       |> wrap_ok()

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -56,8 +56,8 @@ defmodule Livebook.Session.Data do
           deltas: list(Delta.t()),
           revision_by_client_pid: %{pid() => cell_revision()},
           evaluation_digest: String.t() | nil,
-          evaluation_start_time: 0,
-          last_evaluation_time: 0
+          evaluation_start_time: float(),
+          last_evaluation_time: float()
         }
 
   @type cell_revision :: non_neg_integer()

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -57,7 +57,7 @@ defmodule Livebook.Session.Data do
           revision_by_client_pid: %{pid() => cell_revision()},
           evaluation_digest: String.t() | nil,
           evaluation_start_time: float(),
-          evaluation_time_ms: float() | nil
+          evaluation_time_ms: integer() | nil
         }
 
   @type cell_revision :: non_neg_integer()

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -298,8 +298,7 @@ defmodule Livebook.Session.Data do
       data
       |> with_actions()
       |> add_cell_evaluation_response(cell, output)
-      |> finish_cell_evaluation(cell, section)
-      |> finish_cell_evaluation(cell, metadata.evaluation_time_ms)
+      |> finish_cell_evaluation(cell, section, metadata)
       |> mark_dependent_cells_as_stale(cell)
       |> maybe_evaluate_queued()
       |> wrap_ok()
@@ -552,7 +551,7 @@ defmodule Livebook.Session.Data do
       %{section | evaluation_queue: section.evaluation_queue ++ [cell.id]}
     end)
     |> set_cell_info!(cell.id,
-      evaluation_status: :queued,
+      evaluation_status: :queued
     )
   end
 
@@ -604,20 +603,14 @@ defmodule Livebook.Session.Data do
     |> Enum.join("\n")
   end
 
-  defp finish_cell_evaluation(data_actions, cell, section) do
+  defp finish_cell_evaluation(data_actions, cell, section, metadata) do
     data_actions
     |> set_cell_info!(cell.id,
       validity_status: :evaluated,
-      evaluation_status: :ready
+      evaluation_status: :ready,
+      evaluation_time_ms: metadata.evaluation_time_ms
     )
     |> set_section_info!(section.id, evaluating_cell_id: nil)
-  end
-
-  defp finish_cell_evaluation(data_actions, cell, evaluation_time) do
-    data_actions
-    |> set_cell_info!(cell.id,
-      evaluation_time_ms: evaluation_time
-    )
   end
 
   defp mark_dependent_cells_as_stale({data, _} = data_actions, cell) do

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -851,7 +851,7 @@ defmodule LivebookWeb.SessionLive do
       outputs: cell.outputs,
       validity_status: info.validity_status,
       evaluation_status: info.evaluation_status,
-      last_evaluation_time: info.last_evaluation_time
+      evaluation_time_ms: info.evaluation_time_ms
     }
   end
 

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -850,7 +850,8 @@ defmodule LivebookWeb.SessionLive do
       empty?: cell.source == "",
       outputs: cell.outputs,
       validity_status: info.validity_status,
-      evaluation_status: info.evaluation_status
+      evaluation_status: info.evaluation_status,
+      last_evaluation_time: info.last_evaluation_time
     }
   end
 

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -395,7 +395,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       <div class="flex items-center space-x-1">
         <div class="flex text-xs text-gray-400 space-x-1">
           <%= @text %>
-          <%= if @change_indicator do %>
+          <%= if @ change_indicator do %>
             <span data-element="change-indicator">*</span>
           <% end %>
         </div>
@@ -414,12 +414,13 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     evaluation_time =
       if time_ms > 100 do
         seconds = time_ms |> Kernel./(1000) |> Float.floor(1)
-        # {seconds}s"
+        "#{seconds}s"
       else
         "#{time_ms}ms"
       end
 
     "Took " <> evaluation_time
   end
+
   defp evaluated_label(_time_ms), do: nil
 end

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -385,30 +385,36 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       text: text,
       circle_class: circle_class,
       animated_circle_class: Keyword.get(opts, :animated_circle_class),
-      change_indicator: Keyword.get(opts, :change_indicator, false),
-      evaluation_time: Keyword.get(opts, :evaluation_time, 0)
+      change_indicator: Keyword.get(opts, :change_indicator, false)
     }
 
     ~L"""
-    <div class="flex items-center space-x-1">
-      <div class="flex text-xs text-gray-400 space-x-1">
-        <%= @text %>
-        <%= if @change_indicator do %>
-          <span data-element="change-indicator">*</span>
-        <% end %>
-        <%= if @evaluation_time > 100 do %>
-          <span><%= @evaluation_time/1000 %>s</span>
-        <%= else %>
-          <span><%= @evaluation_time %>ms</span>
-        <% end %>
+    <div class="tooltip right distant" aria-label="<%= evaluated_label(opts) %>">
+      <div class="flex items-center space-x-1">
+        <div class="flex text-xs text-gray-400 space-x-1">
+          <%= @text %>
+          <%= if @change_indicator do %>
+            <span data-element="change-indicator">*</span>
+          <% end %>
+        </div>
+        <span class="flex relative h-3 w-3">
+          <%= if @animated_circle_class do %>
+            <span class="animate-ping absolute inline-flex h-3 w-3 rounded-full <%= @animated_circle_class %> opacity-75"></span>
+          <% end %>
+          <span class="relative inline-flex rounded-full h-3 w-3 <%= @circle_class %>"></span>
+        </span>
       </div>
-      <span class="flex relative h-3 w-3">
-        <%= if @animated_circle_class do %>
-          <span class="animate-ping absolute inline-flex h-3 w-3 rounded-full <%= @animated_circle_class %> opacity-75"></span>
-        <% end %>
-        <span class="relative inline-flex rounded-full h-3 w-3 <%= @circle_class %>"></span>
-      </span>
     </div>
     """
+  end
+
+  defp evaluated_label(opts) do
+    evaluation_time =
+      case Keyword.get(opts, :evaluation_time, 0) do
+        sec when sec > 100 -> to_string(sec / 1000) <> "s"
+        ms -> to_string(ms) <> "ms"
+      end
+
+    "Took " <> evaluation_time
   end
 end

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -366,7 +366,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
   defp render_cell_status(:evaluated, _, evaluation_time_ms) do
     render_status_indicator("Evaluated", "bg-green-400",
       change_indicator: true,
-      evaluation_time_ms: evaluation_time_ms
+      tooltip: evaluated_label(evaluation_time_ms)
     )
   end
 
@@ -386,12 +386,11 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       circle_class: circle_class,
       animated_circle_class: Keyword.get(opts, :animated_circle_class),
       change_indicator: Keyword.get(opts, :change_indicator, false),
-      evaluation_time_ms: Keyword.get(opts, :evaluation_time_ms),
-      has_tooltip?: opts |> Keyword.get(:evaluation_time_ms) |> is_nil() == false
+      tooltip: Keyword.get(opts, :tooltip)
     }
 
     ~L"""
-    <div class="<%= if @has_tooltip? do %>tooltip <% end %> bottom distant-medium" aria-label="<%= evaluated_label(@evaluation_time_ms) %>">
+    <div class="<%= if(@tooltip, do: "tooltip") %> bottom distant-medium" aria-label="<%= @tooltip %>">
       <div class="flex items-center space-x-1">
         <div class="flex text-xs text-gray-400 space-x-1">
           <%= @text %>

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -389,7 +389,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     }
 
     ~L"""
-    <div class="tooltip right distant" aria-label="<%= evaluated_label(opts) %>">
+    <div class="tooltip bottom distant-less" aria-label="<%= evaluated_label(opts) %>">
       <div class="flex items-center space-x-1">
         <div class="flex text-xs text-gray-400 space-x-1">
           <%= @text %>

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -366,7 +366,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
   defp render_cell_status(%{validity_status: :evaluated} = cell_view, args) do
     render_status_indicator("Evaluated", "bg-green-400",
       change_indicator: true,
-      evaluation_time: cell_view.evaluation_time_ms
+      evaluation_time_ms: cell_view.evaluation_time_ms
     )
   end
 
@@ -385,11 +385,12 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       text: text,
       circle_class: circle_class,
       animated_circle_class: Keyword.get(opts, :animated_circle_class),
-      change_indicator: Keyword.get(opts, :change_indicator, false)
+      change_indicator: Keyword.get(opts, :change_indicator, false),
+      evaluation_time_ms: Keyword.get(opts, :evaluation_time_ms)
     }
 
     ~L"""
-    <div class="tooltip bottom distant-less" aria-label="<%= evaluated_label(opts) %>">
+    <div class="tooltip bottom distant-medium" aria-label="<%= evaluated_label(@evaluation_time_ms) %>">
       <div class="flex items-center space-x-1">
         <div class="flex text-xs text-gray-400 space-x-1">
           <%= @text %>
@@ -408,13 +409,16 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     """
   end
 
-  defp evaluated_label(opts) do
+  defp evaluated_label(time_ms) when is_integer(time_ms) do
     evaluation_time =
-      case Keyword.get(opts, :evaluation_time, 0) do
-        sec when sec > 100 -> to_string(sec / 1000) <> "s"
-        ms -> to_string(ms) <> "ms"
+      if time_ms > 100 do
+        seconds = time_ms |> Kernel./(1000) |> Float.floor(1)
+        # {seconds}s"
+      else
+        "#{time_ms}ms"
       end
 
     "Took " <> evaluation_time
   end
+  defp evaluated_label(_time_ms), do: nil
 end

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -395,7 +395,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       <div class="flex items-center space-x-1">
         <div class="flex text-xs text-gray-400 space-x-1">
           <%= @text %>
-          <%= if @ change_indicator do %>
+          <%= if @change_indicator do %>
             <span data-element="change-indicator">*</span>
           <% end %>
         </div>

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -224,7 +224,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
       <%= if @cell_view.type == :elixir do %>
         <div class="absolute bottom-2 right-2">
-          <%= render_cell_status(@cell_view, @cell_view.evaluation_status) %>
+          <%= render_cell_status(@cell_view.validity_status, @cell_view.evaluation_status, @cell_view.evaluation_time_ms) %>
         </div>
       <% end %>
     </div>
@@ -350,35 +350,35 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     """
   end
 
-  defp render_cell_status(cell_view, evaluation_status)
+  defp render_cell_status(cell_view, evaluation_status, evaluation_time_ms)
 
-  defp render_cell_status(_, :evaluating) do
+  defp render_cell_status(_, :evaluating, _) do
     render_status_indicator("Evaluating", "bg-blue-500",
       animated_circle_class: "bg-blue-400",
       change_indicator: true
     )
   end
 
-  defp render_cell_status(_, :queued) do
+  defp render_cell_status(_, :queued, _) do
     render_status_indicator("Queued", "bg-gray-500", animated_circle_class: "bg-gray-400")
   end
 
-  defp render_cell_status(%{validity_status: :evaluated} = cell_view, args) do
+  defp render_cell_status(:evaluated, _, evaluation_time_ms) do
     render_status_indicator("Evaluated", "bg-green-400",
       change_indicator: true,
-      evaluation_time_ms: cell_view.evaluation_time_ms
+      evaluation_time_ms: evaluation_time_ms
     )
   end
 
-  defp render_cell_status(%{validity_status: :stale}, _) do
+  defp render_cell_status(:stale, _, _) do
     render_status_indicator("Stale", "bg-yellow-200", change_indicator: true)
   end
 
-  defp render_cell_status(%{validity_status: :aborted}, _) do
+  defp render_cell_status(:aborted, _, _) do
     render_status_indicator("Aborted", "bg-red-400")
   end
 
-  defp render_cell_status(_, _), do: nil
+  defp render_cell_status(_, _, _), do: nil
 
   defp render_status_indicator(text, circle_class, opts \\ []) do
     assigns = %{

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -386,11 +386,12 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       circle_class: circle_class,
       animated_circle_class: Keyword.get(opts, :animated_circle_class),
       change_indicator: Keyword.get(opts, :change_indicator, false),
-      evaluation_time_ms: Keyword.get(opts, :evaluation_time_ms)
+      evaluation_time_ms: Keyword.get(opts, :evaluation_time_ms),
+      has_tooltip?: opts |> Keyword.get(:evaluation_time_ms) |> is_nil() == false
     }
 
     ~L"""
-    <div class="tooltip bottom distant-medium" aria-label="<%= evaluated_label(@evaluation_time_ms) %>">
+    <div class="<%= if @has_tooltip? do %>tooltip <% end %> bottom distant-medium" aria-label="<%= evaluated_label(@evaluation_time_ms) %>">
       <div class="flex items-center space-x-1">
         <div class="flex text-xs text-gray-400 space-x-1">
           <%= @text %>

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -366,7 +366,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
   defp render_cell_status(%{validity_status: :evaluated} = cell_view, args) do
     render_status_indicator("Evaluated", "bg-green-400",
       change_indicator: true,
-      evaluation_time: cell_view.last_evaluation_time
+      evaluation_time: cell_view.evaluation_time_ms
     )
   end
 
@@ -391,13 +391,16 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
     ~L"""
     <div class="flex items-center space-x-1">
-      <div class="flex text-xs text-gray-400">
+      <div class="flex text-xs text-gray-400 space-x-1">
         <%= @text %>
         <%= if @change_indicator do %>
           <span data-element="change-indicator">*</span>
         <% end %>
-        &nbsp;
-        <span><%= @evaluation_time %> seconds</span>
+        <%= if @evaluation_time > 100 do %>
+          <span><%= @evaluation_time/1000 %>s</span>
+        <%= else %>
+          <span><%= @evaluation_time %>ms</span>
+        <% end %>
       </div>
       <span class="flex relative h-3 w-3">
         <%= if @animated_circle_class do %>

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -224,7 +224,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
 
       <%= if @cell_view.type == :elixir do %>
         <div class="absolute bottom-2 right-2">
-          <%= render_cell_status(@cell_view.validity_status, @cell_view.evaluation_status) %>
+          <%= render_cell_status(@cell_view, @cell_view.evaluation_status) %>
         </div>
       <% end %>
     </div>
@@ -350,7 +350,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     """
   end
 
-  defp render_cell_status(validity_status, evaluation_status)
+  defp render_cell_status(cell_view, evaluation_status)
 
   defp render_cell_status(_, :evaluating) do
     render_status_indicator("Evaluating", "bg-blue-500",
@@ -363,15 +363,18 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     render_status_indicator("Queued", "bg-gray-500", animated_circle_class: "bg-gray-400")
   end
 
-  defp render_cell_status(:evaluated, _) do
-    render_status_indicator("Evaluated", "bg-green-400", change_indicator: true)
+  defp render_cell_status(%{validity_status: :evaluated} = cell_view, args) do
+    render_status_indicator("Evaluated", "bg-green-400",
+      change_indicator: true,
+      evaluation_time: cell_view.last_evaluation_time
+    )
   end
 
-  defp render_cell_status(:stale, _) do
+  defp render_cell_status(%{validity_status: :stale}, _) do
     render_status_indicator("Stale", "bg-yellow-200", change_indicator: true)
   end
 
-  defp render_cell_status(:aborted, _) do
+  defp render_cell_status(%{validity_status: :aborted}, _) do
     render_status_indicator("Aborted", "bg-red-400")
   end
 
@@ -382,7 +385,8 @@ defmodule LivebookWeb.SessionLive.CellComponent do
       text: text,
       circle_class: circle_class,
       animated_circle_class: Keyword.get(opts, :animated_circle_class),
-      change_indicator: Keyword.get(opts, :change_indicator, false)
+      change_indicator: Keyword.get(opts, :change_indicator, false),
+      evaluation_time: Keyword.get(opts, :evaluation_time, 0)
     }
 
     ~L"""
@@ -392,6 +396,8 @@ defmodule LivebookWeb.SessionLive.CellComponent do
         <%= if @change_indicator do %>
           <span data-element="change-indicator">*</span>
         <% end %>
+        &nbsp;
+        <span><%= @evaluation_time %> seconds</span>
       </div>
       <span class="flex relative h-3 w-3">
         <%= if @animated_circle_class do %>

--- a/test/livebook/runtime/erl_dist/manager_test.exs
+++ b/test/livebook/runtime/erl_dist/manager_test.exs
@@ -34,7 +34,7 @@ defmodule Livebook.Runtime.ErlDist.ManagerTest do
       Manager.set_owner(node(), self())
       Manager.evaluate_code(node(), "1 + 1", :container1, :evaluation1, nil)
 
-      assert_receive {:evaluation_response, :evaluation1, _}
+      assert_receive {:evaluation_response, :evaluation1, _, %{evaluation_time_ms: _time_ms}}
 
       Manager.stop(node())
     end
@@ -48,8 +48,8 @@ defmodule Livebook.Runtime.ErlDist.ManagerTest do
           Manager.evaluate_code(node(), "defmodule Foo do end", :container1, :evaluation1, nil)
           Manager.evaluate_code(node(), "defmodule Foo do end", :container1, :evaluation2, nil)
 
-          assert_receive {:evaluation_response, :evaluation1, _}
-          assert_receive {:evaluation_response, :evaluation2, _}
+          assert_receive {:evaluation_response, :evaluation1, _, %{evaluation_time_ms: _time_ms}}
+          assert_receive {:evaluation_response, :evaluation2, _, %{evaluation_time_ms: _time_ms}}
         end)
 
       assert stderr == ""
@@ -103,9 +103,10 @@ defmodule Livebook.Runtime.ErlDist.ManagerTest do
       Manager.set_owner(node(), self())
 
       Manager.evaluate_code(node(), "number = 10", :c1, :e1, nil)
-      assert_receive {:evaluation_response, :e1, _}
+      assert_receive {:evaluation_response, :e1, _, %{evaluation_time_ms: _time_ms}}
 
       Manager.request_completion_items(node(), self(), :comp_ref, "num", :c1, :e1)
+
       assert_receive {:completion_response, :comp_ref, [%{label: "number"}]}
 
       Manager.stop(node())

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -1135,7 +1135,7 @@ defmodule Livebook.Session.DataTest do
                 cell_infos: %{"c1" => %{evaluation_time_ms: evaluation_time}}
               }, []} = Data.apply_operation(data, operation)
 
-      assert evaluation_time > 0
+      assert evaluation_time >= 10
     end
   end
 

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -1132,7 +1132,7 @@ defmodule Livebook.Session.DataTest do
 
       assert {:ok,
               %{
-                cell_infos: %{"c1" => %{last_evaluation_time: evaluation_time}}
+                cell_infos: %{"c1" => %{evaluation_time_ms: evaluation_time}}
               }, []} = Data.apply_operation(data, operation)
 
       assert evaluation_time > 0

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -191,9 +191,11 @@ defmodule Livebook.Session.DataTest do
           # Evaluate both cells
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", {:ok, [1, 2, 3]}}
+          {:add_cell_evaluation_response, self(), "c2", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 20}}
         ])
 
       operation = {:delete_cell, self(), "c1"}
@@ -248,13 +250,13 @@ defmodule Livebook.Session.DataTest do
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}, %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}, %{evaluation_time_ms: 20}},
           {:queue_cell_evaluation, self(), "c3"},
-          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}, %{evaluation_time_ms: 30}},
           {:queue_cell_evaluation, self(), "c4"},
-          {:add_cell_evaluation_response, self(), "c4", {:ok, nil}}
+          {:add_cell_evaluation_response, self(), "c4", {:ok, nil}, %{evaluation_time_ms: 40}}
         ])
 
       operation = {:move_cell, self(), "c3", -1}
@@ -289,13 +291,13 @@ defmodule Livebook.Session.DataTest do
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}, %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}, %{evaluation_time_ms: 20}},
           {:queue_cell_evaluation, self(), "c3"},
-          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}, %{evaluation_time_ms: 30}},
           {:queue_cell_evaluation, self(), "c4"},
-          {:add_cell_evaluation_response, self(), "c4", {:ok, nil}}
+          {:add_cell_evaluation_response, self(), "c4", {:ok, nil}, %{evaluation_time_ms: 40}}
         ])
 
       operation = {:move_cell, self(), "c2", 1}
@@ -354,11 +356,11 @@ defmodule Livebook.Session.DataTest do
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}, %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}, %{evaluation_time_ms: 20}},
           {:queue_cell_evaluation, self(), "c3"},
-          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}}
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}, %{evaluation_time_ms: 30}}
         ])
 
       operation = {:move_cell, self(), "c1", 1}
@@ -379,7 +381,7 @@ defmodule Livebook.Session.DataTest do
           # Evaluate the Elixir cell
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}}
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}, %{evaluation_time_ms: 10}}
         ])
 
       operation = {:move_cell, self(), "c2", -1}
@@ -426,9 +428,9 @@ defmodule Livebook.Session.DataTest do
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}, %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c3"},
-          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}}
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}, %{evaluation_time_ms: 20}}
         ])
 
       operation = {:move_cell, self(), "c1", 1}
@@ -474,13 +476,13 @@ defmodule Livebook.Session.DataTest do
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}, %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}, %{evaluation_time_ms: 20}},
           {:queue_cell_evaluation, self(), "c3"},
-          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}, %{evaluation_time_ms: 30}},
           {:queue_cell_evaluation, self(), "c4"},
-          {:add_cell_evaluation_response, self(), "c4", {:ok, nil}}
+          {:add_cell_evaluation_response, self(), "c4", {:ok, nil}, %{evaluation_time_ms: 40}}
         ])
 
       operation = {:move_section, self(), "s2", -1}
@@ -519,13 +521,13 @@ defmodule Livebook.Session.DataTest do
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}, %{evaluation_time_ms: 100}},
           {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}, %{evaluation_time_ms: 20}},
           {:queue_cell_evaluation, self(), "c3"},
-          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}, %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c4"},
-          {:add_cell_evaluation_response, self(), "c4", {:ok, nil}}
+          {:add_cell_evaluation_response, self(), "c4", {:ok, nil}, %{evaluation_time_ms: 0}}
         ])
 
       operation = {:move_section, self(), "s1", 1}
@@ -564,11 +566,11 @@ defmodule Livebook.Session.DataTest do
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}, %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, nil}, %{evaluation_time_ms: 20}},
           {:queue_cell_evaluation, self(), "c3"},
-          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}}
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}, %{evaluation_time_ms: 30}}
         ])
 
       operation = {:move_section, self(), "s1", 1}
@@ -590,7 +592,7 @@ defmodule Livebook.Session.DataTest do
           # Evaluate the Elixir cell
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}}
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}, %{evaluation_time_ms: 10}}
         ])
 
       operation = {:move_section, self(), "s2", -1}
@@ -642,9 +644,9 @@ defmodule Livebook.Session.DataTest do
           # Evaluate cells
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, nil}, %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c3"},
-          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}}
+          {:add_cell_evaluation_response, self(), "c3", {:ok, nil}, %{evaluation_time_ms: 20}}
         ])
 
       operation = {:move_section, self(), "s4", -1}
@@ -814,12 +816,15 @@ defmodule Livebook.Session.DataTest do
           # Evaluate first 2 cells
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", {:ok, [1, 2, 3]}},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 20}},
           # Evaluate the first cell, so the second becomes stale
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}}
+          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 30}}
         ])
 
       # The above leads to:
@@ -954,7 +959,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}}
+          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 10}}
         ])
 
       operation = {:add_cell_evaluation_output, self(), "c1", "Hello!"}
@@ -982,7 +988,8 @@ defmodule Livebook.Session.DataTest do
           {:queue_cell_evaluation, self(), "c1"}
         ])
 
-      operation = {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}}
+      operation =
+        {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}, %{evaluation_time_ms: 10}}
 
       assert {:ok,
               %{
@@ -1006,7 +1013,8 @@ defmodule Livebook.Session.DataTest do
           {:queue_cell_evaluation, self(), "c1"}
         ])
 
-      operation = {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}}
+      operation =
+        {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}, %{evaluation_time_ms: 10}}
 
       assert {:ok,
               %{
@@ -1026,7 +1034,8 @@ defmodule Livebook.Session.DataTest do
           {:queue_cell_evaluation, self(), "c2"}
         ])
 
-      operation = {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}}
+      operation =
+        {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}, %{evaluation_time_ms: 10}}
 
       assert {:ok,
               %{
@@ -1049,7 +1058,8 @@ defmodule Livebook.Session.DataTest do
           {:queue_cell_evaluation, self(), "c2"}
         ])
 
-      operation = {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}}
+      operation =
+        {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}, %{evaluation_time_ms: 10}}
 
       assert {:ok,
               %{
@@ -1097,16 +1107,20 @@ defmodule Livebook.Session.DataTest do
           # Evaluate all cells
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", {:ok, [1, 2, 3]}},
+          {:add_cell_evaluation_response, self(), "c2", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 20}},
           {:queue_cell_evaluation, self(), "c3"},
-          {:add_cell_evaluation_response, self(), "c3", {:ok, [1, 2, 3]}},
+          {:add_cell_evaluation_response, self(), "c3", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 30}},
           # Queue the first cell again
           {:queue_cell_evaluation, self(), "c1"}
         ])
 
-      operation = {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}}
+      operation =
+        {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}, %{evaluation_time_ms: 10}}
 
       assert {:ok,
               %{
@@ -1126,7 +1140,8 @@ defmodule Livebook.Session.DataTest do
           {:queue_cell_evaluation, self(), "c1"}
         ])
 
-      operation = {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}}
+      operation =
+        {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}, %{evaluation_time_ms: 10}}
 
       Process.sleep(10)
 
@@ -1151,7 +1166,8 @@ defmodule Livebook.Session.DataTest do
           {:queue_cell_evaluation, self(), "c1"},
           {:queue_cell_evaluation, self(), "c2"},
           {:queue_cell_evaluation, self(), "c3"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}}
+          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 10}}
         ])
 
       operation = {:reflect_evaluation_failure, self()}
@@ -1184,7 +1200,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 0, :elixir, "c1"},
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}}
+          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 10}}
         ])
 
       operation = {:cancel_cell_evaluation, self(), "c1"}
@@ -1201,7 +1218,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s2", 0, :elixir, "c3"},
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c1"},
-          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}},
+          {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 10}},
           {:queue_cell_evaluation, self(), "c2"},
           {:queue_cell_evaluation, self(), "c3"}
         ])
@@ -1729,7 +1747,8 @@ defmodule Livebook.Session.DataTest do
           {:insert_cell, self(), "s1", 1, :elixir, "c2"},
           {:set_runtime, self(), NoopRuntime.new()},
           {:queue_cell_evaluation, self(), "c2"},
-          {:add_cell_evaluation_response, self(), "c2", {:ok, [1, 2, 3]}}
+          {:add_cell_evaluation_response, self(), "c2", {:ok, [1, 2, 3]},
+           %{evaluation_time_ms: 10}}
         ])
 
       attrs = %{value: "stuff"}

--- a/test/livebook/session/data_test.exs
+++ b/test/livebook/session/data_test.exs
@@ -1116,6 +1116,27 @@ defmodule Livebook.Session.DataTest do
                 }
               }, []} = Data.apply_operation(data, operation)
     end
+
+    test "adds evaluation time to the response" do
+      data =
+        data_after_operations!([
+          {:insert_section, self(), 0, "s1"},
+          {:insert_cell, self(), "s1", 0, :elixir, "c1"},
+          {:set_runtime, self(), NoopRuntime.new()},
+          {:queue_cell_evaluation, self(), "c1"}
+        ])
+
+      operation = {:add_cell_evaluation_response, self(), "c1", {:ok, [1, 2, 3]}}
+
+      Process.sleep(10)
+
+      assert {:ok,
+              %{
+                cell_infos: %{"c1" => %{last_evaluation_time: evaluation_time}}
+              }, []} = Data.apply_operation(data, operation)
+
+      assert evaluation_time > 0
+    end
   end
 
   describe "apply_operation/2 given :reflect_evaluation_failure" do

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -82,7 +82,7 @@ defmodule Livebook.SessionTest do
 
       Session.queue_cell_evaluation(session_id, cell_id)
 
-      assert_receive {:operation, {:add_cell_evaluation_response, _, ^cell_id, _}},
+      assert_receive {:operation, {:add_cell_evaluation_response, _, ^cell_id, _}, %{evaluation_time_ms: _time_ms}},
                      @evaluation_wait_timeout
     end
   end
@@ -376,7 +376,7 @@ defmodule Livebook.SessionTest do
 
     Session.queue_cell_evaluation(session_id, cell_id)
     # Give it a bit more time as this involves starting a system process.
-    assert_receive {:operation, {:add_cell_evaluation_response, _, ^cell_id, _}},
+    assert_receive {:operation, {:add_cell_evaluation_response, _, ^cell_id, _, %{evaluation_time_ms: _time_ms}}},
                    @evaluation_wait_timeout
   end
 
@@ -438,7 +438,7 @@ defmodule Livebook.SessionTest do
       Session.queue_cell_evaluation(session_id, cell_id)
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output}}},
+                      {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output}, %{evaluation_time_ms: _time_ms}}},
                      @evaluation_wait_timeout
 
       assert text_output =~ "Jake Peralta"
@@ -498,7 +498,7 @@ defmodule Livebook.SessionTest do
       Session.queue_cell_evaluation(session_id, cell_id)
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output}}},
+                      {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output}, %{evaluation_time_ms: _time_ms}}},
                      @evaluation_wait_timeout
 
       assert text_output =~ "no matching Livebook input found"

--- a/test/livebook/session_test.exs
+++ b/test/livebook/session_test.exs
@@ -82,7 +82,9 @@ defmodule Livebook.SessionTest do
 
       Session.queue_cell_evaluation(session_id, cell_id)
 
-      assert_receive {:operation, {:add_cell_evaluation_response, _, ^cell_id, _}, %{evaluation_time_ms: _time_ms}},
+      assert_receive {:operation,
+                      {:add_cell_evaluation_response, _, ^cell_id, _,
+                       %{evaluation_time_ms: _time_ms}}},
                      @evaluation_wait_timeout
     end
   end
@@ -376,7 +378,9 @@ defmodule Livebook.SessionTest do
 
     Session.queue_cell_evaluation(session_id, cell_id)
     # Give it a bit more time as this involves starting a system process.
-    assert_receive {:operation, {:add_cell_evaluation_response, _, ^cell_id, _, %{evaluation_time_ms: _time_ms}}},
+    assert_receive {:operation,
+                    {:add_cell_evaluation_response, _, ^cell_id, _,
+                     %{evaluation_time_ms: _time_ms}}},
                    @evaluation_wait_timeout
   end
 
@@ -438,7 +442,8 @@ defmodule Livebook.SessionTest do
       Session.queue_cell_evaluation(session_id, cell_id)
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output}, %{evaluation_time_ms: _time_ms}}},
+                      {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output},
+                       %{evaluation_time_ms: _time_ms}}},
                      @evaluation_wait_timeout
 
       assert text_output =~ "Jake Peralta"
@@ -467,7 +472,8 @@ defmodule Livebook.SessionTest do
       Session.queue_cell_evaluation(session_id, cell_id)
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output}}},
+                      {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output},
+                       %{evaluation_time_ms: _time_ms}}},
                      @evaluation_wait_timeout
 
       assert text_output =~ "no matching Livebook input found"
@@ -498,7 +504,8 @@ defmodule Livebook.SessionTest do
       Session.queue_cell_evaluation(session_id, cell_id)
 
       assert_receive {:operation,
-                      {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output}, %{evaluation_time_ms: _time_ms}}},
+                      {:add_cell_evaluation_response, _, ^cell_id, {:text, text_output},
+                       %{evaluation_time_ms: _time_ms}}},
                      @evaluation_wait_timeout
 
       assert text_output =~ "no matching Livebook input found"


### PR DESCRIPTION
https://user-images.githubusercontent.com/252122/122540937-1cae7880-cff7-11eb-811f-bede091268a7.mov

This change adds the execution time next to the cell indicator.

It is also possible to add a progress bar or display the execution time if is greater than N. The cell info has the previous execution time.

#280 