### PR TITLE
Improve section links behaviour

### DIFF
--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -472,6 +472,14 @@ function focusCellFromUrl(hook) {
     if (getCellById(cellId)) {
       setFocusedCell(hook, cellId);
     }
+  } else {
+    // Explicitly scroll to the target element
+    // after the loading finishes
+    const htmlId = hash.replace(/^#/, "");
+    const element = document.getElementById(htmlId);
+    if (element) {
+      element.scrollIntoView();
+    }
   }
 }
 

--- a/lib/livebook_web/live/session_live/section_component.ex
+++ b/lib/livebook_web/live/session_live/section_component.ex
@@ -4,13 +4,12 @@ defmodule LivebookWeb.SessionLive.SectionComponent do
   def render(assigns) do
     ~L"""
     <div
-      id="<%= @section_view.html_id %>"
       data-element="section"
       data-section-id="<%= @section_view.id %>">
       <div class="flex space-x-4 items-center" data-element="section-headline">
         <h2 class="flex-grow text-gray-800 font-semibold text-2xl px-1 -ml-1 rounded-lg border  border-transparent hover:border-blue-200 focus:border-blue-300"
           data-element="section-name"
-          id="section-<%= @section_view.id %>-name"
+          id="<%= @section_view.html_id %>"
           contenteditable
           spellcheck="false"
           phx-blur="set_section_name"


### PR DESCRIPTION
Closes #359.

When the section title changes, so does the HTML ID, which I believe impacts rendering on morphdom side. When the roundtrip is short, the rendering actually takes place before the new cell button click is handled. Moving the HTML to a more specific element, minimizes its impact and fixes the problem.

Also, I noticed the section link doesn't really work for me, so I updated the code to explicitly scroll to the element once we finish loading (similarly to cell links).