### PR TITLE
Disable busy waiting in release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ COPY config config
 RUN mix do deps.get, deps.compile
 
 # Compile and build the release
+COPY rel rel
 COPY priv priv
 COPY lib lib
 # We need README.md during compilation

--- a/rel/vm.args.eex
+++ b/rel/vm.args.eex
@@ -1,0 +1,3 @@
+# Disable busy waiting, so that we don't waste
+# resources when running in the cloud
++sbwt none +sbwtdcpu none +sbwtdio none


### PR DESCRIPTION
Closes #368.

In the container:

```
/data # cat /app/releases/0.2.0/vm.args 
# Disable busy waiting, so that we don't waste
# resources when running in the cloud
+sbwt none +sbwtdcpu none +sbwtdio none
```