### PR TITLE
Make it possible to mark evaluating cell as stale upfront

### DIFF
--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -378,8 +378,11 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     )
   end
 
-  defp render_cell_status(:stale, _, _) do
-    render_status_indicator("Stale", "bg-yellow-200", change_indicator: true)
+  defp render_cell_status(:stale, _, evaluation_time_ms) do
+    render_status_indicator("Stale", "bg-yellow-200",
+      change_indicator: true,
+      tooltip: evaluated_label(evaluation_time_ms)
+    )
   end
 
   defp render_cell_status(:aborted, _, _) do


### PR DESCRIPTION
If a cell evaluates for a long time and during that time we move/delete cells, the evaluating cell may already be stale and should reflect this fact once it finishes evaluation.