### PR TITLE
Bump the modal's z-index

### DIFF
--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -51,9 +51,6 @@ module.exports = {
           900: '#93112F',
         },
       },
-      zIndex: {
-        1100: 1100,
-      },
     },
   },
   variants: {

--- a/assets/tailwind.config.js
+++ b/assets/tailwind.config.js
@@ -51,6 +51,9 @@ module.exports = {
           900: '#93112F',
         },
       },
+      zIndex: {
+        1100: 1100,
+      },
     },
   },
   variants: {

--- a/lib/livebook_web/live/modal_component.ex
+++ b/lib/livebook_web/live/modal_component.ex
@@ -4,7 +4,7 @@ defmodule LivebookWeb.ModalComponent do
   @impl true
   def render(assigns) do
     ~L"""
-    <div class="fixed z-40 inset-0"
+    <div class="fixed z-1100 inset-0"
       id="<%= @id %>">
 
       <!-- Modal container -->

--- a/lib/livebook_web/live/modal_component.ex
+++ b/lib/livebook_web/live/modal_component.ex
@@ -4,7 +4,7 @@ defmodule LivebookWeb.ModalComponent do
   @impl true
   def render(assigns) do
     ~L"""
-    <div class="fixed z-1100 inset-0"
+    <div class="fixed z-[10000] inset-0"
       id="<%= @id %>">
 
       <!-- Modal container -->


### PR DESCRIPTION
I noticed that the z-index of Vega-lite's menu button was `1000` but the modal's z-index is `40`. I did not see any options to drop the z-index in vega-lite, so I bumped the modal. Perhaps not ideal to have to have components keep one-upping their z-index, but seems ok given that modals are usually set quite high.

<img width="1199" alt="Screen Shot 2021-06-23 at 7 07 31 AM" src="https://user-images.githubusercontent.com/606233/123112626-b492d480-d3f2-11eb-9f8e-04aebf1fc960.png">

<img width="1199" alt="Screen Shot 2021-06-23 at 7 07 43 AM" src="https://user-images.githubusercontent.com/606233/123112638-b6f52e80-d3f2-11eb-8249-619938774211.png">

