### PR TITLE
Update README.md to include installation of Erlang applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You will need [Elixir v1.12](https://elixir-lang.org/install.html) or later as w
 
 On Ubuntu, these Erlang applications can be installed as follows:
 ```shell
-sudo apt install erlang-inets erlang-os-mon, erlang-runtime-tools, erlang-ssl
+sudo apt install erlang-inets erlang-os-mon erlang-runtime-tools erlang-ssl
 ```
 
 ### Escript

--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ From time to time, we also publish some videos for new Livebook releases:
 We provide several distinct methods of running Livebook,
 pick the one that best fits your use case.
 
-You will need [Elixir v1.12](https://elixir-lang.org/install.html) or later.
+You will need [Elixir v1.12](https://elixir-lang.org/install.html) or later as well as the following Erlang applications: `inets`, `os_mon`, `runtime-tools`, `ssl`
+
+On Ubuntu, these Erlang applications can be installed as follows:
+```shell
+sudo apt install erlang-inets erlang-os-mon, erlang-runtime-tools, erlang-ssl
+```
 
 ### Escript
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,13 @@ From time to time, we also publish some videos for new Livebook releases:
 We provide several distinct methods of running Livebook,
 pick the one that best fits your use case.
 
-You will need [Elixir v1.12](https://elixir-lang.org/install.html) or later as well as the following Erlang applications: `inets`, `os_mon`, `runtime-tools`, `ssl`
+You will need [Elixir v1.12](https://elixir-lang.org/install.html) or later.
+Livebook also requires the following Erlang applications: `inets`,
+`os_mon`, `runtime_tools`, and `ssl`. Those applications come with
+most Erlang distributions but certain package manages may split
+them apart. For example, on Ubuntu, these Erlang applications could
+be installed as follows:
 
-On Ubuntu, these Erlang applications can be installed as follows:
 ```shell
 sudo apt install erlang-inets erlang-os-mon erlang-runtime-tools erlang-ssl
 ```


### PR DESCRIPTION
I was unable to start Livebook after installing via escript. It failed with this cryptic error:
```
20:19:19.259 [info] Application runtime_tools exited: :stopped
Livebook failed to start
```

Installing with mix showed that `os_mon` needed to be installed. I've updated the README to include the installation of these extra applications.