### PR TITLE
Update z-index of menu

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -156,7 +156,7 @@
   /* Toggleable menu */
 
   .menu {
-    @apply absolute right-0 z-20 rounded-lg bg-white flex flex-col py-2;
+    @apply absolute right-0 z-30 rounded-lg bg-white flex flex-col py-2;
     box-shadow: 0px 15px 99px rgba(13, 24, 41, 0.15);
   }
 


### PR DESCRIPTION
The buttons of a cell were rendered in front of the menu, because both had the same `z-index` of `20` (see Screenshot).
Bumped the `z-index` of the menu to `30` to prevent that.

<img width="1502" alt="Screenshot 2021-06-24 at 16 26 27" src="https://user-images.githubusercontent.com/792046/123282126-843e5980-d50a-11eb-8105-679cacf9a259.png">
