### PR TITLE
add escript option to support ipv6 addresses

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,8 @@ defmodule Livebook.MixProject do
   defp escript do
     [
       main_module: LivebookCLI,
-      app: nil
+      app: nil,
+      emu_args: "-proto_dist inet6_tcp"
     ]
   end
 


### PR DESCRIPTION
Add config to escript build that supports ipv6 addresses. Avoids having to specify the config through ENV settings.