### PR TITLE
Normalize textarea newlines

### DIFF
--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -432,6 +432,10 @@ defmodule LivebookWeb.SessionLive do
   end
 
   def handle_event("set_cell_value", %{"cell_id" => cell_id, "value" => value}, socket) do
+    # The browser may normalize newlines to \r\n, but we want \n
+    # to more closely imitate an actual shell
+    value = String.replace(value, "\r\n", "\n")
+
     Session.set_cell_attributes(socket.assigns.session_id, cell_id, %{value: value})
 
     {:noreply, socket}


### PR DESCRIPTION
The browser sends textarea newlines as `\r\n`, while we want `\n` as in shell.

![image](https://user-images.githubusercontent.com/17034772/123424995-d5f5eb00-d5c1-11eb-832a-d697f1460184.png)