### PR TITLE
Remove the cmd + space autocomplete instructions from example livebook

### DIFF
--- a/lib/livebook/notebook/explore/elixir_and_livebook.livemd
+++ b/lib/livebook/notebook/explore/elixir_and_livebook.livemd
@@ -21,8 +21,7 @@ Let's move on.
 ## Autocompletion
 
 Elixir code cells also support autocompletion by
-pressing <kbd>ctrl</kbd> + <kbd>␣</kbd>
-(<kbd>⌘</kbd> + <kbd>␣</kbd> on a Mac). Try it out by
+pressing <kbd>ctrl</kbd> + <kbd>␣</kbd>. Try it out by
 autocompleting the code below to `System.version()`. First put
 the cursor after the `.` below and
 press <kbd>ctrl</kbd>&nbsp;+&nbsp;<kbd>␣</kbd>:


### PR DESCRIPTION
Macs use ctrl + space and don't special case this shortcut

This ended up being a super trivial PR, I did a search and the cmd + space doesn't seem to be mentioned in any other notebooks. As pointed out on the issue the main documentation is correct already too. 

Closes: #403 