### PR TITLE
Add code formatting integration to Elixir cells

### DIFF
--- a/assets/js/cell/live_editor/monaco.js
+++ b/assets/js/cell/live_editor/monaco.js
@@ -40,6 +40,19 @@ monaco.languages.registerCompletionItemProvider("elixir", {
   },
 });
 
+// Define custom code formatting provider.
+// Formatting is cell agnostic, but we still delegate
+// to a cell specific implementation to communicate with LV.
+monaco.languages.registerDocumentFormattingEditProvider("elixir", {
+  provideDocumentFormattingEdits: function (model, options, token) {
+    if (model.__getDocumentFormattingEdits) {
+      return model.__getDocumentFormattingEdits(model);
+    } else {
+      return [];
+    }
+  },
+});
+
 export default monaco;
 
 /**

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -612,6 +612,19 @@ defmodule LivebookWeb.SessionLive do
     {:noreply, socket}
   end
 
+  def handle_event("format_code", %{"code" => code}, socket) do
+    formatted =
+      try do
+        code
+        |> Code.format_string!()
+        |> IO.iodata_to_binary()
+      rescue
+        _ -> code
+      end
+
+    {:reply, %{code: formatted}, socket}
+  end
+
   defp create_session(socket, opts) do
     case SessionSupervisor.create_session(opts) do
       {:ok, id} ->

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -4,13 +4,24 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
   @shortcuts %{
     insert_mode: [
       %{seq: ["esc"], desc: "Switch back to navigation mode"},
-      %{seq: ["ctrl", "↵"], press_all: true, desc: "Evaluate cell and stay in insert mode"},
+      %{
+        seq: ["ctrl", "↵"],
+        seq_mac: ["⌘", "↵"],
+        press_all: true,
+        desc: "Evaluate cell and stay in insert mode"
+      },
       %{seq: ["tab"], desc: "Autocomplete expression when applicable"},
       %{
         seq: ["ctrl", "␣"],
         press_all: true,
-        transform_for_mac: false,
         desc: "Show completion list, use twice for details"
+      },
+      %{
+        seq: ["ctrl", "shift", "i"],
+        seq_mac: ["⇧", "⌥", "f"],
+        seq_windows: ["shift", "alt", "f"],
+        press_all: true,
+        desc: "Format Elixir code"
       }
     ],
     navigation_mode: [
@@ -36,7 +47,7 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
       %{seq: ["s", "b"], desc: "Show bin"}
     ],
     universal: [
-      %{seq: ["ctrl", "s"], press_all: true, desc: "Save notebook"}
+      %{seq: ["ctrl", "s"], seq_mac: ["⌘", "s"], press_all: true, desc: "Save notebook"}
     ]
   }
 
@@ -74,7 +85,7 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
     <h3 class="text-lg font-medium text-gray-900 pt-4">
       <%= @title %>
     </h3>
-    <div class="mt-2 flex sm:flex-row flex-col">
+    <div class="mt-2 flex flex-col sm:flex-row sm:space-x-2">
       <div class="flex-grow">
         <%= render_shortcuts_section_table(@left, @platform) %>
       </div>
@@ -107,18 +118,12 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
   end
 
   defp render_shortcut_seq(shortcut, platform) do
-    seq =
-      if platform == :mac and Map.get(shortcut, :transform_for_mac, true) do
-        seq_for_mac(shortcut.seq)
-      else
-        shortcut.seq
-      end
-
+    seq = shortcut[:"seq_#{platform}"] || shortcut.seq
     press_all = Map.get(shortcut, :press_all, false)
 
     joiner =
       if press_all do
-        remix_icon("add-line", class: "text-xl text-gray-600")
+        remix_icon("add-line", class: "text-lg text-gray-600")
       end
 
     elements = Enum.map_intersperse(seq, joiner, &content_tag("kbd", &1))
@@ -131,14 +136,6 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
       <% end %>
     </div>
     """
-  end
-
-  defp seq_for_mac(seq) do
-    Enum.map(seq, fn
-      "ctrl" -> "⌘"
-      "alt" -> "⌥"
-      key -> key
-    end)
   end
 
   defp split_in_half(list) do


### PR DESCRIPTION
Closes #296.

I figured out a way that should overcome the concerns I had with formatting and is actually pretty simple. There is a detailed comment in the code, but the important parts are:

* user originates the formatting and it happens within editor as a regular edit (consequently it's a normal operation on the undo stack)
* the formatting operation isn't a replace-all, but a set of operations that introduce the minimal diff, consequently the Delta sent from the client is reasonable, which should make conflict resolution work reliably if needed
* formatting is only applied if the editor is intact, any change (remote or local) cancels the formatting, and that eliminates a whole category of conflicts


https://user-images.githubusercontent.com/17034772/124037620-20cb9480-da00-11eb-9380-d89861d634f8.mp4

