### PR TITLE
Suggest restarting runtime on Mix.install error and add restart shortcut

### DIFF
--- a/assets/js/session/index.js
+++ b/assets/js/session/index.js
@@ -301,6 +301,8 @@ function handleDocumentKeyDown(hook, event) {
       showBin(hook);
     } else if (keyBuffer.tryMatch(["e", "x"])) {
       cancelFocusedCellEvaluation(hook);
+    } else if (keyBuffer.tryMatch(["0", "0"])) {
+      restartRuntime(hook);
     } else if (keyBuffer.tryMatch(["?"])) {
       showShortcuts(hook);
     } else if (keyBuffer.tryMatch(["i"])) {
@@ -592,6 +594,10 @@ function cancelFocusedCellEvaluation(hook) {
       cell_id: hook.state.focusedCellId,
     });
   }
+}
+
+function restartRuntime(hook) {
+  hook.pushEvent("restart_runtime", {});
 }
 
 function showShortcuts(hook) {

--- a/lib/livebook/evaluator/default_formatter.ex
+++ b/lib/livebook/evaluator/default_formatter.ex
@@ -27,7 +27,7 @@ defmodule Livebook.Evaluator.DefaultFormatter do
 
   def format_response({:error, kind, error, stacktrace}) do
     formatted = Exception.format(kind, error, stacktrace)
-    {:error, formatted}
+    {:error, formatted, error_type(error)}
   end
 
   @compile {:no_warn_undefined, {Kino.Render, :to_livebook, 1}}
@@ -79,5 +79,16 @@ defmodule Livebook.Evaluator.DefaultFormatter do
       # tuple: :light_black,
       reset: :reset
     ]
+  end
+
+  defp error_type(error) do
+    cond do
+      mix_install_vm_error?(error) -> :mix_install_vm_error
+      true -> :other
+    end
+  end
+
+  defp mix_install_vm_error?(exception) do
+    Exception.message(exception) =~ "Mix.install/2 can only be called with the same dependencies"
   end
 end

--- a/lib/livebook/evaluator/default_formatter.ex
+++ b/lib/livebook/evaluator/default_formatter.ex
@@ -83,12 +83,14 @@ defmodule Livebook.Evaluator.DefaultFormatter do
 
   defp error_type(error) do
     cond do
-      mix_install_vm_error?(error) -> :mix_install_vm_error
+      mix_install_vm_error?(error) -> :runtime_restart_required
       true -> :other
     end
   end
 
   defp mix_install_vm_error?(exception) do
-    Exception.message(exception) =~ "Mix.install/2 can only be called with the same dependencies"
+    is_struct(exception, Mix.Error) and
+      Exception.message(exception) =~
+        "Mix.install/2 can only be called with the same dependencies"
   end
 end

--- a/lib/livebook/notebook/cell/elixir.ex
+++ b/lib/livebook/notebook/cell/elixir.ex
@@ -38,7 +38,7 @@ defmodule Livebook.Notebook.Cell.Elixir do
           # Interactive data table
           | {:table_dynamic, widget_process :: pid()}
           # Internal output format for errors
-          | {:error, message :: binary(), type :: :other | :mix_install_vm_error}
+          | {:error, message :: binary(), type :: :other | :runtime_restart_required}
 
   @doc """
   Returns an empty cell.

--- a/lib/livebook/notebook/cell/elixir.ex
+++ b/lib/livebook/notebook/cell/elixir.ex
@@ -38,7 +38,7 @@ defmodule Livebook.Notebook.Cell.Elixir do
           # Interactive data table
           | {:table_dynamic, widget_process :: pid()}
           # Internal output format for errors
-          | {:error, message :: binary()}
+          | {:error, message :: binary(), type :: :other | :mix_install_vm_error}
 
   @doc """
   Returns an empty cell.

--- a/lib/livebook/runtime.ex
+++ b/lib/livebook/runtime.ex
@@ -106,4 +106,10 @@ defprotocol Livebook.Runtime do
         container_ref,
         evaluation_ref
       )
+
+  @doc """
+  Synchronously starts a runtime of the same type with the same parameters.
+  """
+  @spec duplicate(Runtime.t()) :: {:ok, Runtime.t()} | {:error, String.t()}
+  def duplicate(runtime)
 end

--- a/lib/livebook/runtime/attached.ex
+++ b/lib/livebook/runtime/attached.ex
@@ -89,4 +89,8 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Attached do
       evaluation_ref
     )
   end
+
+  def duplicate(_runtime) do
+    {:error, "attached runtime is connected to a specific VM and cannot be duplicated"}
+  end
 end

--- a/lib/livebook/runtime/elixir_standalone.ex
+++ b/lib/livebook/runtime/elixir_standalone.ex
@@ -113,4 +113,8 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.ElixirStandalone do
       evaluation_ref
     )
   end
+
+  def duplicate(_runtime) do
+    Livebook.Runtime.ElixirStandalone.init()
+  end
 end

--- a/lib/livebook/runtime/embedded.ex
+++ b/lib/livebook/runtime/embedded.ex
@@ -95,4 +95,9 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.Embedded do
       evaluation_ref
     )
   end
+
+  def duplicate(_runtime) do
+    {:error,
+     "embedded runtime is connected to the Livebook application VM and cannot be duplicated"}
+  end
 end

--- a/lib/livebook/runtime/mix_standalone.ex
+++ b/lib/livebook/runtime/mix_standalone.ex
@@ -166,4 +166,8 @@ defimpl Livebook.Runtime, for: Livebook.Runtime.MixStandalone do
       evaluation_ref
     )
   end
+
+  def duplicate(runtime) do
+    Livebook.Runtime.MixStandalone.init(runtime.project_path)
+  end
 end

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -566,6 +566,24 @@ defmodule LivebookWeb.SessionLive do
      push_patch(socket, to: Routes.session_path(socket, :bin, socket.assigns.session_id))}
   end
 
+  def handle_event("restart_runtime", %{}, socket) do
+    socket =
+      if runtime = socket.private.data.runtime do
+        case Runtime.duplicate(runtime) do
+          {:ok, new_runtime} ->
+            Session.connect_runtime(socket.assigns.session_id, new_runtime)
+            socket
+
+          {:error, message} ->
+            put_flash(socket, :error, "Failed to setup runtime - #{message}")
+        end
+      else
+        socket
+      end
+
+    {:noreply, socket}
+  end
+
   def handle_event("completion_request", %{"hint" => hint, "cell_id" => cell_id}, socket) do
     data = socket.private.data
 

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -337,7 +337,7 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     )
   end
 
-  defp render_output(_socket, {:error, formatted, :mix_install_vm_error}, _id) do
+  defp render_output(_socket, {:error, formatted, :runtime_restart_required}, _id) do
     assigns = %{formatted: formatted}
 
     ~L"""

--- a/lib/livebook_web/live/session_live/cell_component.ex
+++ b/lib/livebook_web/live/session_live/cell_component.ex
@@ -337,7 +337,22 @@ defmodule LivebookWeb.SessionLive.CellComponent do
     )
   end
 
-  defp render_output(_socket, {:error, formatted}, _id) do
+  defp render_output(_socket, {:error, formatted, :mix_install_vm_error}, _id) do
+    assigns = %{formatted: formatted}
+
+    ~L"""
+    <div class="flex flex-col space-y-4">
+      <%= render_error_message_output(@formatted) %>
+      <div>
+        <button class="button button-gray" phx-click="restart_runtime">
+          Restart runtime
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  defp render_output(_socket, {:error, formatted, _type}, _id) do
     render_error_message_output(formatted)
   end
 

--- a/lib/livebook_web/live/session_live/shortcuts_component.ex
+++ b/lib/livebook_web/live/session_live/shortcuts_component.ex
@@ -33,7 +33,8 @@ defmodule LivebookWeb.SessionLive.ShortcutsComponent do
       %{seq: ["s", "s"], desc: "Toggle sections panel"},
       %{seq: ["s", "u"], desc: "Toggle users panel"},
       %{seq: ["s", "r"], desc: "Show runtime settings"},
-      %{seq: ["s", "b"], desc: "Show bin"}
+      %{seq: ["s", "b"], desc: "Show bin"},
+      %{seq: ["0", "0"], desc: "Restart current runtime"}
     ],
     universal: [
       %{seq: ["ctrl", "s"], press_all: true, desc: "Save notebook"}

--- a/test/support/noop_runtime.ex
+++ b/test/support/noop_runtime.ex
@@ -15,5 +15,6 @@ defmodule Livebook.Runtime.NoopRuntime do
     def forget_evaluation(_, _, _), do: :ok
     def drop_container(_, _), do: :ok
     def request_completion_items(_, _, _, _, _, _), do: :ok
+    def duplicate(_), do: {:ok, Livebook.Runtime.NoopRuntime.new()}
   end
 end


### PR DESCRIPTION
Shows a "Restart runtime" button upon `Mix.install/2` failure, as @wojtekmach suggested :sunglasses: 

Also a <kbd>0</kbd><kbd>0</kbd> shortcut, ref: https://github.com/elixir-nx/livebook/issues/408#issuecomment-869052279.

https://user-images.githubusercontent.com/17034772/124113970-5312db80-da6c-11eb-9a56-22cd2feb9d8e.mp4

