### PR TITLE
Make it possible to embed Livebook within another Phoenix app

### DIFF
--- a/lib/livebook/config.ex
+++ b/lib/livebook/config.ex
@@ -40,6 +40,22 @@ defmodule Livebook.Config do
     Application.fetch_env!(:livebook, :root_path)
   end
 
+  @doc """
+  Return the name of the router's helpers module.
+  """
+  @spec router_helpers_module() :: atom()
+  def router_helpers_module() do
+    Application.get_env(:livebook, :router_helpers_module, LivebookWeb.Router.Helpers)
+  end
+
+  @doc """
+  Return the base url for livebook.
+  """
+  @spec base_url_path() :: binary()
+  def base_url_path() do
+    Application.get_env(:livebook, :base_url_path, "/")
+  end
+
   ## Parsing
 
   @doc """

--- a/lib/livebook_web.ex
+++ b/lib/livebook_web.ex
@@ -6,7 +6,7 @@ defmodule LivebookWeb do
       use Phoenix.Controller, namespace: LivebookWeb
 
       import Plug.Conn
-      alias LivebookWeb.Router.Helpers, as: Routes
+      alias unquote(Livebook.Config.router_helpers_module), as: Routes
     end
   end
 
@@ -62,7 +62,7 @@ defmodule LivebookWeb do
 
       # Import basic rendering functionality (render, render_layout, etc)
       import Phoenix.View
-      alias LivebookWeb.Router.Helpers, as: Routes
+      alias unquote(Livebook.Config.router_helpers_module), as: Routes
 
       # Custom helpers
       import LivebookWeb.Helpers

--- a/lib/livebook_web/helpers.ex
+++ b/lib/livebook_web/helpers.ex
@@ -1,7 +1,6 @@
 defmodule LivebookWeb.Helpers do
   import Phoenix.LiveView.Helpers
   import Phoenix.HTML.Tag
-  alias LivebookWeb.Router.Helpers, as: Routes
 
   @doc """
   Renders a component inside the `Livebook.ModalComponent` component.
@@ -84,7 +83,7 @@ defmodule LivebookWeb.Helpers do
   """
   def live_dashboard_process_path(socket, pid) do
     pid_str = Phoenix.LiveDashboard.Helpers.encode_pid(pid)
-    Routes.live_dashboard_path(socket, :page, node(), "processes", info: pid_str)
+    Livebook.Config.router_helpers_module().live_dashboard_path(socket, :page, node(), "processes", info: pid_str)
   end
 
   @doc """

--- a/lib/livebook_web/live/session_helpers.ex
+++ b/lib/livebook_web/live/session_helpers.ex
@@ -1,6 +1,5 @@
 defmodule LivebookWeb.SessionHelpers do
   import Phoenix.LiveView
-  alias LivebookWeb.Router.Helpers, as: Routes
 
   @doc """
   Creates a new session, redirects on success,
@@ -12,7 +11,7 @@ defmodule LivebookWeb.SessionHelpers do
   def create_session(socket, opts \\ []) do
     case Livebook.SessionSupervisor.create_session(opts) do
       {:ok, id} ->
-        push_redirect(socket, to: Routes.session_path(socket, :page, id))
+        push_redirect(socket, to: Livebook.Config.router_helpers_module().session_path(socket, :page, id))
 
       {:error, reason} ->
         put_flash(socket, :error, "Failed to create session: #{reason}")

--- a/lib/livebook_web/router.ex
+++ b/lib/livebook_web/router.ex
@@ -16,36 +16,6 @@ defmodule LivebookWeb.Router do
     plug LivebookWeb.UserPlug
   end
 
-  scope "/", LivebookWeb do
-    pipe_through [:browser, :auth]
+  use LivebookWeb.Routes
 
-    live "/", HomeLive, :page
-    live "/home/user-profile", HomeLive, :user
-    live "/home/import/:tab", HomeLive, :import
-    live "/home/sessions/:session_id/close", HomeLive, :close_session
-    live "/explore", ExploreLive, :page
-    live "/explore/user-profile", ExploreLive, :user
-    live "/explore/notebooks/:slug", ExploreLive, :notebook
-    live "/sessions/:id", SessionLive, :page
-    live "/sessions/:id/user-profile", SessionLive, :user
-    live "/sessions/:id/shortcuts", SessionLive, :shortcuts
-    live "/sessions/:id/settings/runtime", SessionLive, :runtime_settings
-    live "/sessions/:id/settings/file", SessionLive, :file_settings
-    live "/sessions/:id/bin", SessionLive, :bin
-    live "/sessions/:id/cell-settings/:cell_id", SessionLive, :cell_settings
-    live "/sessions/:id/cell-upload/:cell_id", SessionLive, :cell_upload
-    live "/sessions/:id/delete-section/:section_id", SessionLive, :delete_section
-    get "/sessions/:id/images/:image", SessionController, :show_image
-
-    live_dashboard "/dashboard",
-      metrics: LivebookWeb.Telemetry,
-      home_app: {"Livebook", :livebook}
-  end
-
-  scope "/authenticate", LivebookWeb do
-    pipe_through :browser
-
-    get "/", AuthController, :index
-    post "/", AuthController, :authenticate
-  end
 end

--- a/lib/livebook_web/routes.ex
+++ b/lib/livebook_web/routes.ex
@@ -1,0 +1,59 @@
+defmodule LivebookWeb.Routes do
+
+  def main_paths() do
+    quote do
+      live "/", HomeLive, :page
+      live "/home/user-profile", HomeLive, :user
+      live "/home/import/:tab", HomeLive, :import
+      live "/home/sessions/:session_id/close", HomeLive, :close_session
+      live "/explore", ExploreLive, :page
+      live "/explore/user-profile", ExploreLive, :user
+      live "/explore/notebooks/:slug", ExploreLive, :notebook
+      live "/sessions/:id", SessionLive, :page
+      live "/sessions/:id/user-profile", SessionLive, :user
+      live "/sessions/:id/shortcuts", SessionLive, :shortcuts
+      live "/sessions/:id/settings/runtime", SessionLive, :runtime_settings
+      live "/sessions/:id/settings/file", SessionLive, :file_settings
+      live "/sessions/:id/bin", SessionLive, :bin
+      live "/sessions/:id/cell-settings/:cell_id", SessionLive, :cell_settings
+      live "/sessions/:id/cell-upload/:cell_id", SessionLive, :cell_upload
+      live "/sessions/:id/delete-section/:section_id", SessionLive, :delete_section
+      get "/sessions/:id/images/:image", SessionController, :show_image
+    end
+  end
+
+  def live_dashboard_path() do
+    quote do
+      live_dashboard "/dashboard",
+        metrics: LivebookWeb.Telemetry,
+        home_app: {"Livebook", :livebook}
+    end
+  end
+
+  def authenticate_paths() do
+    quote do
+      get "/", AuthController, :index
+      post "/", AuthController, :authenticate
+    end
+  end
+
+  defmacro __using__(_) do
+
+    quote do
+
+      scope unquote(Livebook.Config.base_url_path), LivebookWeb do
+        pipe_through [:browser, :auth]
+
+        unquote(main_paths())
+        unquote(live_dashboard_path())
+      end
+
+      scope unquote(Livebook.Config.base_url_path)<>"/authenticate", LivebookWeb do
+        pipe_through :browser
+
+        unquote(authenticate_paths())
+      end
+
+    end
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -8,7 +8,7 @@ defmodule LivebookWeb.ConnCase do
       import Phoenix.ConnTest
       import LivebookWeb.ConnCase
 
-      alias LivebookWeb.Router.Helpers, as: Routes
+      alias unquote(Livebook.Config.router_helpers_module), as: Routes
 
       # The default endpoint for testing
       @endpoint LivebookWeb.Endpoint


### PR DESCRIPTION
I like the ability to run Livebook in embedded mode, and wanted to run it within an app that already has Phoenix routes defined, but needed a few tweaks to make that work:

- made base url configurable (defaults to "/")
- made the router helper used to generate links configurable (defaults to the one Livebook ships: `LivebookWeb.Router.Helpers`)
- put the routes in a module from which they are pulled into the router (or can be pulled into the parent's app existing router)

Of course if there are preferable approaches to this I'm happy to adjust... :crossed_fingers: 