### PR TITLE
Handle backticks in Elixir code when persisting Livemarkdown

### DIFF
--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -39,11 +39,12 @@ defmodule Livebook.LiveMarkdown.Export do
 
   defp render_cell(%Cell.Elixir{} = cell) do
     code = get_elixir_cell_code(cell)
+    delimiter = code_block_delimiter(code)
 
     """
-    ```elixir
+    #{delimiter}elixir
     #{code}
-    ```\
+    #{delimiter}\
     """
     |> prepend_metadata(cell.metadata)
   end
@@ -117,10 +118,22 @@ defmodule Livebook.LiveMarkdown.Export do
 
   defp format_code(code) do
     try do
-      Code.format_string!(code)
+      code
+      |> Code.format_string!()
+      |> IO.iodata_to_binary()
     rescue
       _ -> code
     end
+  end
+
+  defp code_block_delimiter(code) do
+    max_streak =
+      Regex.scan(~r/`{3,}/, code)
+      |> Enum.map(fn [string] -> String.length(string) end)
+      |> Enum.max(&>=/2, fn -> 0 end)
+
+    backticks = max(max_streak + 1, 3)
+    String.duplicate("`", backticks)
   end
 
   defp put_truthy(map, entries) do

--- a/lib/livebook/live_markdown/export.ex
+++ b/lib/livebook/live_markdown/export.ex
@@ -129,11 +129,10 @@ defmodule Livebook.LiveMarkdown.Export do
   defp code_block_delimiter(code) do
     max_streak =
       Regex.scan(~r/`{3,}/, code)
-      |> Enum.map(fn [string] -> String.length(string) end)
-      |> Enum.max(&>=/2, fn -> 0 end)
+      |> Enum.map(fn [string] -> byte_size(string) end)
+      |> Enum.max(&>=/2, fn -> 2 end)
 
-    backticks = max(max_streak + 1, 3)
-    String.duplicate("`", backticks)
+    String.duplicate("`", max_streak + 1)
   end
 
   defp put_truthy(map, entries) do

--- a/lib/livebook/notebook/explore/intro_to_kino.livemd
+++ b/lib/livebook/notebook/explore/intro_to_kino.livemd
@@ -154,7 +154,7 @@ most busy processes!
 Sometimes you may want to render arbitrary content as rich-text,
 that's when `Kino.Markdown.new/1` comes into play:
 
-```elixir
+````elixir
 """
 # Example
 
@@ -174,7 +174,7 @@ A regular Markdown file.
 | 2  | Erlang | https://www.erlang.org  |
 """
 |> Kino.Markdown.new()
-```
+````
 
 ## Kino.render/1
 

--- a/test/livebook/live_markdown/export_test.exs
+++ b/test/livebook/live_markdown/export_test.exs
@@ -418,4 +418,57 @@ defmodule Livebook.LiveMarkdown.ExportTest do
 
     assert expected_document == document
   end
+
+  test "handles backticks in code cell" do
+    notebook = %{
+      Notebook.new()
+      | name: "My Notebook",
+        metadata: %{},
+        sections: [
+          %{
+            Notebook.Section.new()
+            | name: "Section 1",
+              metadata: %{},
+              cells: [
+                %{
+                  Notebook.Cell.new(:elixir)
+                  | source: """
+                    \"\"\"
+                    ```elixir
+                    x = 1
+                    ```
+
+                    ````markdown
+                    # Heading
+                    ````
+                    \"\"\"\
+                    """
+                }
+              ]
+          }
+        ]
+    }
+
+    expected_document = """
+    # My Notebook
+
+    ## Section 1
+
+    `````elixir
+    \"\"\"
+    ```elixir
+    x = 1
+    ```
+
+    ````markdown
+    # Heading
+    ````
+    \"\"\"
+    `````
+    """
+
+    document = Export.notebook_to_markdown(notebook)
+
+    assert expected_document == document
+  end
 end


### PR DESCRIPTION
An Elixir cell may have 3+ backticks, so we cannot use the same number of backticks for persisting the cell. Fortunately Markdown allows more than 3 backticks, so we can use max bacticks + 1 when persisting.