### PR TITLE
Resolve links for imported notebooks

### DIFF
--- a/lib/livebook/content_loader.ex
+++ b/lib/livebook/content_loader.ex
@@ -55,8 +55,23 @@ defmodule Livebook.ContentLoader do
 
   @doc """
   Loads binary content from the given URl and validates if its plain text.
+
+  Supports local file:// URLs and remote http(s):// URLs.
   """
   @spec fetch_content(String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def fetch_content(url)
+
+  def fetch_content("file://" <> path) do
+    case File.read(path) do
+      {:ok, content} ->
+        {:ok, content}
+
+      {:error, error} ->
+        message = :file.format_error(error)
+        {:error, "failed to read #{path}, reason: #{message}"}
+    end
+  end
+
   def fetch_content(url) do
     case :httpc.request(:get, {url, []}, http_opts(), body_format: :binary) do
       {:ok, {{_, 200, _}, headers, body}} ->

--- a/lib/livebook/session/data.ex
+++ b/lib/livebook/session/data.ex
@@ -16,6 +16,7 @@ defmodule Livebook.Session.Data do
 
   defstruct [
     :notebook,
+    :origin_url,
     :path,
     :dirty,
     :section_infos,
@@ -32,6 +33,7 @@ defmodule Livebook.Session.Data do
 
   @type t :: %__MODULE__{
           notebook: Notebook.t(),
+          origin_url: String.t() | nil,
           path: nil | String.t(),
           dirty: boolean(),
           section_infos: %{Section.id() => section_info()},
@@ -126,6 +128,7 @@ defmodule Livebook.Session.Data do
   def new(notebook \\ Notebook.new()) do
     %__MODULE__{
       notebook: notebook,
+      origin_url: nil,
       path: nil,
       dirty: false,
       section_infos: initial_section_infos(notebook),

--- a/lib/livebook/utils.ex
+++ b/lib/livebook/utils.ex
@@ -121,18 +121,59 @@ defmodule Livebook.Utils do
 
   ## Examples
 
-    iex> Livebook.Utils.valid_hex_color?("#111111")
-    true
+      iex> Livebook.Utils.valid_hex_color?("#111111")
+      true
 
-    iex> Livebook.Utils.valid_hex_color?("#ABC123")
-    true
+      iex> Livebook.Utils.valid_hex_color?("#ABC123")
+      true
 
-    iex> Livebook.Utils.valid_hex_color?("ABCDEF")
-    false
+      iex> Livebook.Utils.valid_hex_color?("ABCDEF")
+      false
 
-    iex> Livebook.Utils.valid_hex_color?("#111")
-    false
+      iex> Livebook.Utils.valid_hex_color?("#111")
+      false
   """
   @spec valid_hex_color?(String.t()) :: boolean()
   def valid_hex_color?(hex_color), do: hex_color =~ ~r/^#[0-9a-fA-F]{6}$/
+
+  @doc """
+  Changes the first letter in the given string to upper case.
+
+  ## Examples
+
+      iex> Livebook.Utils.upcase_first("sippin tea")
+      "Sippin tea"
+
+      iex> Livebook.Utils.upcase_first("short URL")
+      "Short URL"
+
+      iex> Livebook.Utils.upcase_first("")
+      ""
+  """
+  @spec upcase_first(String.t()) :: String.t()
+  def upcase_first(string) do
+    {first, rest} = String.split_at(string, 1)
+    String.upcase(first) <> rest
+  end
+
+  @doc """
+  Expands a relative path in terms of the given URL.
+
+  ## Examples
+
+      iex> Livebook.Utils.expand_url("file:///home/user/lib/file.ex", "../root.ex")
+      "file:///home/user/root.ex"
+
+      iex> Livebook.Utils.expand_url("https://example.com/lib/file.ex?token=supersecret", "../root.ex")
+      "https://example.com/root.ex?token=supersecret"
+  """
+  @spec expand_url(String.t(), String.t()) :: String.t()
+  def expand_url(url, relative_path) do
+    url
+    |> URI.parse()
+    |> Map.update!(:path, fn path ->
+      path |> Path.dirname() |> Path.join(relative_path) |> Path.expand()
+    end)
+    |> URI.to_string()
+  end
 end

--- a/lib/livebook_web/live/home_live/import_content_component.ex
+++ b/lib/livebook_web/live/home_live/import_content_component.ex
@@ -37,7 +37,7 @@ defmodule LivebookWeb.HomeLive.ImportContentComponent do
   end
 
   def handle_event("import", %{"data" => %{"content" => content}}, socket) do
-    send(self(), {:import_content, content})
+    send(self(), {:import_content, content, []})
 
     {:noreply, socket}
   end

--- a/lib/livebook_web/live/home_live/import_url_component.ex
+++ b/lib/livebook_web/live/home_live/import_url_component.ex
@@ -50,11 +50,11 @@ defmodule LivebookWeb.HomeLive.ImportUrlComponent do
     |> ContentLoader.fetch_content()
     |> case do
       {:ok, content} ->
-        send(self(), {:import_content, content})
+        send(self(), {:import_content, content, [origin_url: url]})
         {:noreply, socket}
 
       {:error, message} ->
-        {:noreply, assign(socket, error_message: String.capitalize(message))}
+        {:noreply, assign(socket, error_message: Utils.upcase_first(message))}
     end
   end
 end

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -765,7 +765,10 @@ defmodule LivebookWeb.SessionLive do
 
           {:error, :many} ->
             socket
-            |> put_flash(:error, "Multiple sessions found for #{target_url}")
+            |> put_flash(
+              :error,
+              "Cannot navigate, because multiple sessions were found for #{target_url}"
+            )
             |> redirect_to_self()
         end
     end
@@ -793,7 +796,7 @@ defmodule LivebookWeb.SessionLive do
 
       {:error, message} ->
         socket
-        |> put_flash(:error, Livebook.Utils.upcase_first(message))
+        |> put_flash(:error, "Cannot navigate, " <> message)
         |> redirect_to_self()
     end
   end

--- a/lib/livebook_web/live/session_live.ex
+++ b/lib/livebook_web/live/session_live.ex
@@ -733,58 +733,101 @@ defmodule LivebookWeb.SessionLive do
 
       true ->
         socket
-        |> push_patch(to: Routes.session_path(socket, :page, socket.assigns.session_id))
         |> put_flash(
           :error,
           "Got unrecognised session path: #{path}\nIf you want to link another notebook, make sure to include the .livemd extension"
         )
+        |> redirect_to_self()
     end
   end
 
   defp handle_relative_notebook_path(socket, relative_path) do
-    case socket.private.data.path do
+    resolution_url = location(socket.private.data)
+
+    case resolution_url do
       nil ->
         socket
         |> put_flash(
           :info,
-          "Cannot resolve notebook path #{relative_path}, because the current notebook has no file"
+          "Cannot resolve notebook path #{relative_path}, because the current notebook has no location"
         )
-        |> push_patch(to: Routes.session_path(socket, :page, socket.assigns.session_id))
+        |> redirect_to_self()
 
-      path ->
-        target_path = path |> Path.dirname() |> Path.join(relative_path) |> Path.expand()
-        maybe_open_notebook(socket, target_path)
+      url ->
+        target_url = Livebook.Utils.expand_url(url, relative_path)
+
+        case session_id_by_url(target_url) do
+          {:ok, session_id} ->
+            push_redirect(socket, to: Routes.session_path(socket, :page, session_id))
+
+          {:error, :none} ->
+            open_notebook(socket, target_url)
+
+          {:error, :many} ->
+            socket
+            |> put_flash(:error, "Multiple sessions found for #{target_url}")
+            |> redirect_to_self()
+        end
     end
   end
 
-  defp maybe_open_notebook(socket, path) do
-    if session_id = session_id_by_path(path) do
-      push_redirect(socket, to: Routes.session_path(socket, :page, session_id))
+  defp location(data)
+  defp location(%{path: path}) when is_binary(path), do: "file://" <> path
+  defp location(%{origin_url: origin_url}), do: origin_url
+
+  defp open_notebook(socket, url) do
+    url
+    |> Livebook.ContentLoader.rewrite_url()
+    |> Livebook.ContentLoader.fetch_content()
+    |> case do
+      {:ok, content} ->
+        {notebook, messages} = Livebook.LiveMarkdown.Import.notebook_from_markdown(content)
+
+        # If the current session has no path, fork the notebook
+        fork? = socket.private.data.path == nil
+        {path, notebook} = path_and_notebook(fork?, url, notebook)
+
+        socket
+        |> put_import_flash_messages(messages)
+        |> create_session(notebook: notebook, origin_url: url, path: path)
+
+      {:error, message} ->
+        socket
+        |> put_flash(:error, Livebook.Utils.upcase_first(message))
+        |> redirect_to_self()
+    end
+  end
+
+  defp path_and_notebook(fork?, url, notebook)
+  defp path_and_notebook(false, "file://" <> path, notebook), do: {path, notebook}
+  defp path_and_notebook(true, "file://" <> _path, notebook), do: {nil, Notebook.forked(notebook)}
+  defp path_and_notebook(_fork?, _url, notebook), do: {nil, notebook}
+
+  defp session_id_by_url(url) do
+    session_summaries = SessionSupervisor.get_session_summaries()
+
+    session_with_path =
+      Enum.find(session_summaries, fn summary ->
+        summary.path && "file://" <> summary.path == url
+      end)
+
+    # A session associated with the given path takes
+    # precedence over sessions originating from this path
+    if session_with_path do
+      {:ok, session_with_path.session_id}
     else
-      case File.read(path) do
-        {:ok, content} ->
-          {notebook, messages} = LiveMarkdown.Import.notebook_from_markdown(content)
-
-          socket
-          |> put_import_flash_messages(messages)
-          |> create_session(notebook: notebook, path: path)
-
-        {:error, error} ->
-          message = :file.format_error(error)
-
-          socket
-          |> put_flash(:error, "Failed to open #{path}, reason: #{message}")
-          |> push_patch(to: Routes.session_path(socket, :page, socket.assigns.session_id))
+      session_summaries
+      |> Enum.filter(fn summary -> summary.origin_url == url end)
+      |> case do
+        [summary] -> {:ok, summary.session_id}
+        [] -> {:error, :none}
+        _ -> {:error, :many}
       end
     end
   end
 
-  defp session_id_by_path(path) do
-    session_summaries = SessionSupervisor.get_session_summaries()
-
-    Enum.find_value(session_summaries, fn summary ->
-      summary.path == path && summary.session_id
-    end)
+  defp redirect_to_self(socket) do
+    push_patch(socket, to: Routes.session_path(socket, :page, socket.assigns.session_id))
   end
 
   defp after_operation(socket, _prev_socket, {:client_join, client_pid, user}) do

--- a/test/livebook/content_loader_test.exs
+++ b/test/livebook/content_loader_test.exs
@@ -25,7 +25,27 @@ defmodule Livebook.ContentLoaderTest do
     end
   end
 
-  describe "fetch_content/1" do
+  describe "fetch_content/1 with local file URL" do
+    @tag :tmp_dir
+    test "returns an error then the file cannot be read", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "nonexistent.livemd")
+      url = "file://" <> path
+
+      assert ContentLoader.fetch_content(url) ==
+               {:error, "failed to read #{path}, reason: no such file or directory"}
+    end
+
+    @tag :tmp_dir
+    test "returns file contents when read successfully", %{tmp_dir: tmp_dir} do
+      path = Path.join(tmp_dir, "notebook.livemd")
+      File.write!(path, "# My notebook")
+      url = "file://" <> path
+
+      assert ContentLoader.fetch_content(url) == {:ok, "# My notebook"}
+    end
+  end
+
+  describe "fetch_content/1 with remote URL" do
     setup do
       bypass = Bypass.open()
       {:ok, bypass: bypass}

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -447,7 +447,7 @@ defmodule LivebookWeb.SessionLiveTest do
       {:ok, view, _} = follow_redirect(result, conn)
 
       assert render(view) =~
-               "Failed to read #{notebook_path}, reason: no such file or directory"
+               "Cannot navigate, failed to read #{notebook_path}, reason: no such file or directory"
     end
 
     @tag :tmp_dir
@@ -589,7 +589,7 @@ defmodule LivebookWeb.SessionLiveTest do
                result = live(conn, "/sessions/#{session_id}/notebook.livemd")
 
       {:ok, view, _} = follow_redirect(result, conn)
-      assert render(view) =~ "Failed to download notebook from the given URL"
+      assert render(view) =~ "Cannot navigate, failed to download notebook from the given URL"
     end
 
     test "if the remote notebook is already imported, redirects to the session",
@@ -621,7 +621,9 @@ defmodule LivebookWeb.SessionLiveTest do
                result = live(conn, "/sessions/#{index_session_id}/notebook.livemd")
 
       {:ok, view, _} = follow_redirect(result, conn)
-      assert render(view) =~ "Multiple sessions found for #{notebook_url}"
+
+      assert render(view) =~
+               "Cannot navigate, because multiple sessions were found for #{notebook_url}"
     end
   end
 

--- a/test/livebook_web/live/session_live_test.exs
+++ b/test/livebook_web/live/session_live_test.exs
@@ -417,7 +417,7 @@ defmodule LivebookWeb.SessionLiveTest do
       assert render(view) =~ "Got unrecognised session path: document.pdf"
     end
 
-    test "renders an info message when the session has no associated path",
+    test "renders an info message when the session has neither original url nor path",
          %{conn: conn, session_id: session_id} do
       session_path = "/sessions/#{session_id}"
 
@@ -427,7 +427,7 @@ defmodule LivebookWeb.SessionLiveTest do
       {:ok, view, _} = follow_redirect(result, conn)
 
       assert render(view) =~
-               "Cannot resolve notebook path notebook.livemd, because the current notebook has no file"
+               "Cannot resolve notebook path notebook.livemd, because the current notebook has no location"
     end
 
     @tag :tmp_dir
@@ -447,7 +447,7 @@ defmodule LivebookWeb.SessionLiveTest do
       {:ok, view, _} = follow_redirect(result, conn)
 
       assert render(view) =~
-               "Failed to open #{notebook_path}, reason: no such file or directory"
+               "Failed to read #{notebook_path}, reason: no such file or directory"
     end
 
     @tag :tmp_dir
@@ -461,12 +461,37 @@ defmodule LivebookWeb.SessionLiveTest do
 
       File.write!(notebook_path, "# Sibling notebook")
 
-      assert {:error, {:live_redirect, %{to: _session_path}}} =
+      assert {:error, {:live_redirect, %{to: new_session_path}}} =
                result = live(conn, "/sessions/#{session_id}/notebook.livemd")
 
       {:ok, view, _} = follow_redirect(result, conn)
-
       assert render(view) =~ "Sibling notebook"
+
+      "/sessions/" <> session_id = new_session_path
+      data = Session.get_data(session_id)
+      assert data.path == notebook_path
+    end
+
+    @tag :tmp_dir
+    test "if the current session has no path, forks the relative notebook",
+         %{conn: conn, tmp_dir: tmp_dir} do
+      index_path = Path.join(tmp_dir, "index.livemd")
+      notebook_path = Path.join(tmp_dir, "notebook.livemd")
+
+      {:ok, session_id} = SessionSupervisor.create_session(origin_url: "file://" <> index_path)
+
+      File.write!(notebook_path, "# Sibling notebook")
+
+      assert {:error, {:live_redirect, %{to: new_session_path}}} =
+               result = live(conn, "/sessions/#{session_id}/notebook.livemd")
+
+      {:ok, view, _} = follow_redirect(result, conn)
+      assert render(view) =~ "Sibling notebook - fork"
+
+      "/sessions/" <> session_id = new_session_path
+      data = Session.get_data(session_id)
+      assert data.path == nil
+      assert data.origin_url == "file://" <> notebook_path
     end
 
     @tag :tmp_dir
@@ -526,6 +551,78 @@ defmodule LivebookWeb.SessionLiveTest do
 
       assert render(view) =~ "Parent notebook"
     end
+
+    test "resolves remote URLs", %{conn: conn} do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/notebook.livemd", fn conn ->
+        conn
+        |> Plug.Conn.put_resp_content_type("text/plain")
+        |> Plug.Conn.resp(200, "# My notebook")
+      end)
+
+      index_url = url(bypass.port) <> "/index.livemd"
+      {:ok, session_id} = SessionSupervisor.create_session(origin_url: index_url)
+
+      {:ok, view, _} =
+        conn
+        |> live("/sessions/#{session_id}/notebook.livemd")
+        |> follow_redirect(conn)
+
+      assert render(view) =~ "My notebook"
+    end
+
+    test "renders an error message if relative remote notebook cannot be loaded", %{conn: conn} do
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/notebook.livemd", fn conn ->
+        Plug.Conn.resp(conn, 500, "Error")
+      end)
+
+      index_url = url(bypass.port) <> "/index.livemd"
+
+      {:ok, session_id} = SessionSupervisor.create_session(origin_url: index_url)
+
+      session_path = "/sessions/#{session_id}"
+
+      assert {:error, {:live_redirect, %{to: ^session_path}}} =
+               result = live(conn, "/sessions/#{session_id}/notebook.livemd")
+
+      {:ok, view, _} = follow_redirect(result, conn)
+      assert render(view) =~ "Failed to download notebook from the given URL"
+    end
+
+    test "if the remote notebook is already imported, redirects to the session",
+         %{conn: conn, test: test} do
+      index_url = "http://example.com/#{test}/index.livemd"
+      notebook_url = "http://example.com/#{test}/notebook.livemd"
+
+      {:ok, index_session_id} = SessionSupervisor.create_session(origin_url: index_url)
+      {:ok, notebook_session_id} = SessionSupervisor.create_session(origin_url: notebook_url)
+
+      notebook_session_path = "/sessions/#{notebook_session_id}"
+
+      assert {:error, {:live_redirect, %{to: ^notebook_session_path}}} =
+               live(conn, "/sessions/#{index_session_id}/notebook.livemd")
+    end
+
+    test "renders an error message if there are already multiple session imported from the relative URL",
+         %{conn: conn, test: test} do
+      index_url = "http://example.com/#{test}/index.livemd"
+      notebook_url = "http://example.com/#{test}/notebook.livemd"
+
+      {:ok, index_session_id} = SessionSupervisor.create_session(origin_url: index_url)
+      {:ok, _notebook_session_id1} = SessionSupervisor.create_session(origin_url: notebook_url)
+      {:ok, _notebook_session_id2} = SessionSupervisor.create_session(origin_url: notebook_url)
+
+      index_session_path = "/sessions/#{index_session_id}"
+
+      assert {:error, {:live_redirect, %{to: ^index_session_path}}} =
+               result = live(conn, "/sessions/#{index_session_id}/notebook.livemd")
+
+      {:ok, view, _} = follow_redirect(result, conn)
+      assert render(view) =~ "Multiple sessions found for #{notebook_url}"
+    end
   end
 
   # Helpers
@@ -572,4 +669,6 @@ defmodule LivebookWeb.SessionLiveTest do
     {:ok, user} = User.new() |> User.change(%{"name" => name})
     user
   end
+
+  defp url(port), do: "http://localhost:#{port}"
 end


### PR DESCRIPTION
Followup to #441, closes #423.

Each session has an `origin_url`, which informs from where the notebook was imported. This can be both local `file://` or remote `http(s)://` URL. We use this information later to resolve relative notebook links. If the session has an associated path, it always takes precedence. Also, we always look for sessions with matching `path` or `origin_url`, before creating a new one.

https://user-images.githubusercontent.com/17034772/125116212-acbe7a00-e0ec-11eb-98dc-1f7ed1c57aaa.mp4